### PR TITLE
Increase thread pool size for scheduled jobs

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,11 @@ spring:
     port: 6672
     virtualhost: /
 
+  task:
+    scheduling:
+      pool:
+        size: 2
+
 queueconfig:
   inbound-queue: case.action
   action-fulfilment-inbound-queue: action.fulfilment


### PR DESCRIPTION
# Motivation and Context:
The healthchecks were failing and causing k8s to reboot the action worker.

# What has changed?
Increased the size of the thread pool for scheduled jobs.

# How to test?
Run it with a massive load of work to do so the main scheduled task is busy for a long time.

# Links:
Trello: https://trello.com/c/LheDlxV7