### PR TITLE
Add ceActualResponses to action-worker export to fwmt

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
@@ -33,6 +33,7 @@ public class FieldworkFollowupBuilder {
     followup.setFieldOfficerId(caze.getFieldOfficerId());
     followup.setFieldCoordinatorId(caze.getFieldCoordinatorId());
     followup.setCeExpectedCapacity(caze.getCeExpectedCapacity());
+    followup.setCeActualResponses(caze.getCeActualResponses());
     followup.setUndeliveredAsAddress(caze.isUndeliveredAsAddressed());
 
     // TODO: set surveyName, undeliveredAsAddress and blankQreReturned from caze

--- a/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
@@ -25,7 +25,8 @@ public class FieldworkFollowup {
   private String treatmentCode;
   private String fieldOfficerId;
   private String fieldCoordinatorId;
-  private String ceExpectedCapacity;
+  private Integer ceExpectedCapacity;
+  private Integer ceActualResponses;
   private String surveyName;
   private Boolean undeliveredAsAddress;
   private Boolean blankQreReturned;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -73,7 +73,10 @@ public class Case {
   @Column(name = "treatment_code")
   private String treatmentCode;
 
-  @Column private String ceExpectedCapacity;
+  @Column private Integer ceExpectedCapacity;
+
+  @Column
+  private Integer ceActualResponses;
 
   @Column private String collectionExerciseId;
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -75,8 +75,7 @@ public class Case {
 
   @Column private Integer ceExpectedCapacity;
 
-  @Column
-  private Integer ceActualResponses;
+  @Column private Integer ceActualResponses;
 
   @Column private String collectionExerciseId;
 

--- a/src/test/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilderTest.java
@@ -19,7 +19,6 @@ public class FieldworkFollowupBuilderTest {
     Case caze = easyRandom.nextObject(Case.class);
     caze.setLatitude("1.123456789999");
     caze.setLongitude("-9.987654321111");
-    caze.setCeExpectedCapacity("500");
 
     ActionRule actionRule = generateRandomActionRule(easyRandom);
 
@@ -39,6 +38,8 @@ public class FieldworkFollowupBuilderTest {
     // Given
     EasyRandom easyRandom = new EasyRandom();
     Case caze = easyRandom.nextObject(Case.class);
+    caze.setCeExpectedCapacity(500);
+    caze.setCeActualResponses(234);
 
     ActionRule actionRule = generateRandomActionRule(easyRandom);
 

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -259,6 +259,7 @@ public class ChunkPollerIT {
 
     ActionPlan actionPlan = setUpActionPlan();
     Case randomCase = setUpCase(actionPlan);
+
     ActionRule actionRule = setUpActionRule(ActionType.FIELD, actionPlan);
 
     // Force the action rule to trigger
@@ -272,6 +273,7 @@ public class ChunkPollerIT {
     assertThat(actualMessage).isNotNull();
     FieldworkFollowup actualFieldworkFollowup =
         objectMapper.readValue(actualMessage, FieldworkFollowup.class);
+
     assertThat(actualFieldworkFollowup.getCaseRef())
         .isEqualTo(Integer.toString(randomCase.getCaseRef()));
 
@@ -283,6 +285,9 @@ public class ChunkPollerIT {
         .isEqualTo(randomCase.getCaseRef());
     assertThat(actualRmEvent.getPayload().getFieldCaseSelected().getActionRuleId())
         .isEqualTo(actionRule.getId().toString());
+
+    assertThat(actualFieldworkFollowup.getCeActualResponses())
+        .isEqualTo(randomCase.getCeActualResponses());
   }
 
   private UacQidDTO stubCreateWelshUacQid() throws JsonProcessingException {


### PR DESCRIPTION
# Motivation and Context:
Needed to get ceActualResponses to fwmt

# What has changed?
added ceActualResponses to case entity and now sets it in export

# How to test?
There are IT and unit tests.  But there can be no ATs at present as the ceActualResponses column isn't updated from 0 by any code.

A cheap way might be to run to populate the DB, then
Clear down the RM.Field Queue in your local rabbit

Make sure they're the right type and ce_actual_responses has a value
Update actionv2.cases Set receipt_received = false, ce_actual_responses = 5, address_level = 'E'; commit;
Then refire the action rule
Update actionv2.action_rule set has_triggered = false; Commit;

Then check your RM.Field queue in Rabbit, Get Message the ceActualResponse should be 5.

# Links:
https://trello.com/c/gIGqWwlV/493-fixes-to-ce
# Screenshots (if appropriate):