### PR TITLE
Remove case state

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -81,10 +81,6 @@ public class Case {
 
   @Column private String actionPlanId;
 
-  @Column
-  @Enumerated(EnumType.STRING)
-  private CaseState state;
-
   @Column(name = "receipt_received", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean receiptReceived;
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/CaseState.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/CaseState.java
@@ -1,5 +1,0 @@
-package uk.gov.ons.census.action.model.entity;
-
-public enum CaseState {
-  ACTIONABLE
-}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can now safely remove the redundant case `state` column from our schemas

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed `state` from the repo

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Make sure tests and acceptance tests still pass from the links below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dBJe87ZS/481-get-rid-of-casestate-from-case-table-8

https://github.com/ONSdigital/census-rm-case-processor/pull/101
https://github.com/ONSdigital/census-rm-case-api/pull/53
https://github.com/ONSdigital/census-rm-action-scheduler/pull/64
https://github.com/ONSdigital/census-rm-ddl/pull/32
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/169