### PR TITLE
RMC-317: Add handDelivery on outbound messages

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/FieldworkFollowupBuilder.java
@@ -35,6 +35,7 @@ public class FieldworkFollowupBuilder {
     followup.setCeExpectedCapacity(caze.getCeExpectedCapacity());
     followup.setCeActualResponses(caze.getCeActualResponses());
     followup.setUndeliveredAsAddress(caze.isUndeliveredAsAddressed());
+    followup.setHandDelivery(caze.isHandDelivery());
 
     // TODO: set surveyName, undeliveredAsAddress and blankQreReturned from caze
     followup.setSurveyName("CENSUS");

--- a/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
@@ -30,5 +30,5 @@ public class FieldworkFollowup {
   private String surveyName;
   private Boolean undeliveredAsAddress;
   private Boolean blankQreReturned;
-  private boolean handDelivery;
+  private Boolean handDelivery;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/FieldworkFollowup.java
@@ -30,4 +30,5 @@ public class FieldworkFollowup {
   private String surveyName;
   private Boolean undeliveredAsAddress;
   private Boolean blankQreReturned;
+  private boolean handDelivery;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -92,4 +92,7 @@ public class Case {
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
+
+  @Column(columnDefinition = "BOOLEAN DEFAULT false")
+  private boolean handDelivery;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -93,6 +93,6 @@ public class Case {
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
 
-  @Column(columnDefinition = "BOOLEAN DEFAULT false")
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean handDelivery;
 }

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -288,7 +288,7 @@ public class ChunkPollerIT {
 
     assertThat(actualFieldworkFollowup.getCeActualResponses())
         .isEqualTo(randomCase.getCeActualResponses());
-    assertThat(actualFieldworkFollowup.isHandDelivery()).isEqualTo(randomCase.isHandDelivery());
+    assertThat(actualFieldworkFollowup.getHandDelivery()).isEqualTo(randomCase.isHandDelivery());
   }
 
   private UacQidDTO stubCreateWelshUacQid() throws JsonProcessingException {

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -288,6 +288,7 @@ public class ChunkPollerIT {
 
     assertThat(actualFieldworkFollowup.getCeActualResponses())
         .isEqualTo(randomCase.getCeActualResponses());
+    assertThat(actualFieldworkFollowup.isHandDelivery()).isEqualTo(randomCase.isHandDelivery());
   }
 
   private UacQidDTO stubCreateWelshUacQid() throws JsonProcessingException {


### PR DESCRIPTION
# Motivation and Context:
<!--- Why is this change required? What problem does it solve? -->
We need to add `handDeliver` bool flag on each of our outgoing Action Instruction `CREATE` messages to Field. 

# What has changed?
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Added flag to field followup messages

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check build, run ATs against links below

# Links:
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/774V6fGU/580-add-handdelivery-flag-to-casecreated-and-caseupdated-events-and-case-api-8

https://github.com/ONSdigital/census-rm-action-scheduler/pull/65
https://github.com/ONSdigital/census-rm-ddl/pull/38
https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/30
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/191
https://github.com/ONSdigital/census-rm-case-processor/pull/112