### PR TITLE
Bump Spring version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.3.RELEASE</version>
+    <version>2.2.7.RELEASE</version>
   </parent>
 
   <properties>
@@ -115,7 +115,7 @@
       <plugin>
         <groupId>com.dkanejs.maven.plugins</groupId>
         <artifactId>docker-compose-maven-plugin</artifactId>
-        <version>2.4.0</version>
+        <version>4.0.0</version>
         <executions>
           <execution>
             <id>up</id>


### PR DESCRIPTION
# Motivation and Context
We should keep Spring Boot up to date, because newer versions contain many security, stability and performance improvements, and it ensures that we never end up running an unsupported old version

# What has changed
Bumped Spring up to v2.2.7.

# How to test?
Should be zero regression.

# Links
Trello: https://trello.com/c/sNmbnD6B