### PR TITLE
Initial contact != reminder letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # census-rm-action-worker
 [![Build Status](https://api.travis-ci.com/ONSdigital/census-rm-action-worker.svg?branch=master)](https://travis-ci.com/ONSdigital/census-rm-action-worker)
-
+ 
 # Overview
 The Action Worker is a horizontally scalable microservice which processes cases which have been chosen by an action rule to be sent to the printer or Fieldwork service.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # census-rm-action-worker
 [![Build Status](https://api.travis-ci.com/ONSdigital/census-rm-action-worker.svg?branch=master)](https://travis-ci.com/ONSdigital/census-rm-action-worker)
- 
+
 # Overview
 The Action Worker is a horizontally scalable microservice which processes cases which have been chosen by an action rule to be sent to the printer or Fieldwork service.
 

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -16,7 +16,8 @@ public class PrintFileDtoBuilder {
           ActionType.P_RL_1RL2BA,
           ActionType.P_RL_2RL1A,
           ActionType.P_RL_2RL2BA
-          // NO. DO NOT ADD ANYTHING TO THIS LIST. NOPE. NEVER.
+          // Adding to this list will result in no UAC being sent on the printed
+          // letter/questionnaire. Please be certain of what you're doing before adding to it.
           );
   private final UacQidLinkBuilder uacQidLinkBuilder;
 
@@ -29,7 +30,8 @@ public class PrintFileDtoBuilder {
 
     PrintFileDto printFileDto = new PrintFileDto();
 
-    // "EQ launched but not submitted/completed" reminders don't need a UAC-QID pair
+    // "EQ launched but not submitted/completed" reminders don't have a UAC-QID pair for security
+    // because the respondent has already partially filled in their EQ.
     if (!doesNotRequireUacQidActionTypes.contains(actionType)) {
       UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType);
 

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -10,7 +10,7 @@ import uk.gov.ons.census.action.model.entity.Case;
 
 @Component
 public class PrintFileDtoBuilder {
-  private static final Set<ActionType> responseDrivenReminderActionTypes =
+  private static final Set<ActionType> doesNotRequireUacQidActionTypes =
       Set.of(
           ActionType.P_RL_1RL1A,
           ActionType.P_RL_1RL2BA,
@@ -29,8 +29,8 @@ public class PrintFileDtoBuilder {
 
     PrintFileDto printFileDto = new PrintFileDto();
 
-    // Response driven reminders don't need a UAC-QID pair
-    if (!responseDrivenReminderActionTypes.contains(actionType)) {
+    // "EQ launched but not submitted/completed" reminders don't need a UAC-QID pair
+    if (!doesNotRequireUacQidActionTypes.contains(actionType)) {
       UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType);
 
       printFileDto.setUac(uacQidTuple.getUacQidLink().getUac());

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.action.builders;
 
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.action.model.UacQidTuple;
@@ -9,6 +10,14 @@ import uk.gov.ons.census.action.model.entity.Case;
 
 @Component
 public class PrintFileDtoBuilder {
+  private static final Set<ActionType> responseDrivenReminderActionTypes =
+      Set.of(
+          ActionType.P_RL_1RL1A,
+          ActionType.P_RL_1RL2BA,
+          ActionType.P_RL_2RL1A,
+          ActionType.P_RL_2RL2BA
+          // NO. DO NOT ADD ANYTHING TO THIS LIST. NOPE. NEVER.
+          );
   private final UacQidLinkBuilder uacQidLinkBuilder;
 
   public PrintFileDtoBuilder(UacQidLinkBuilder uacQidLinkBuilder) {
@@ -18,15 +27,19 @@ public class PrintFileDtoBuilder {
   public PrintFileDto buildPrintFileDto(
       Case selectedCase, String packCode, UUID batchUUID, ActionType actionType) {
 
-    UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType);
-
     PrintFileDto printFileDto = new PrintFileDto();
-    printFileDto.setUac(uacQidTuple.getUacQidLink().getUac());
-    printFileDto.setQid(uacQidTuple.getUacQidLink().getQid());
 
-    if (uacQidTuple.getUacQidLinkWales().isPresent()) {
-      printFileDto.setUacWales(uacQidTuple.getUacQidLinkWales().get().getUac());
-      printFileDto.setQidWales(uacQidTuple.getUacQidLinkWales().get().getQid());
+    // Response driven reminders don't need a UAC-QID pair
+    if (!responseDrivenReminderActionTypes.contains(actionType)) {
+      UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType);
+
+      printFileDto.setUac(uacQidTuple.getUacQidLink().getUac());
+      printFileDto.setQid(uacQidTuple.getUacQidLink().getQid());
+
+      if (uacQidTuple.getUacQidLinkWales().isPresent()) {
+        printFileDto.setUacWales(uacQidTuple.getUacQidLinkWales().get().getUac());
+        printFileDto.setQidWales(uacQidTuple.getUacQidLinkWales().get().getQid());
+      }
     }
 
     printFileDto.setCaseRef(selectedCase.getCaseRef());

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -27,7 +27,7 @@ import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
 
 @Component
 public class UacQidLinkBuilder {
-  private static final Set<ActionType> uacQidPreGeneratedActionTypes =
+  private static final Set<ActionType> initialContactActionTypes =
       Set.of(
           ActionType.ICHHQE,
           ActionType.ICHHQW,
@@ -42,11 +42,9 @@ public class UacQidLinkBuilder {
           ActionType.SPG_IC11,
           ActionType.SPG_IC12,
           ActionType.SPG_IC13,
-          ActionType.SPG_IC14,
-          ActionType.P_RL_1RL1A,
-          ActionType.P_RL_1RL2BA,
-          ActionType.P_RL_2RL1A,
-          ActionType.P_RL_2RL2BA);
+          ActionType.SPG_IC14
+          // NO. DO NOT ADD ANYTHING TO THIS LIST. NOPE. NEVER.
+          );
 
   private static final String ADDRESS_LEVEL_ESTAB = "E";
 
@@ -86,7 +84,7 @@ public class UacQidLinkBuilder {
   }
 
   public UacQidTuple getUacQidLinks(Case linkedCase, ActionType actionType) {
-    if (isUacQidPreGeneratedActionType(actionType)) {
+    if (isInitialContactActionType(actionType)) {
       return fetchExistingUacQidPairsForAction(linkedCase, actionType);
     } else if (isCeIndividualActionType(actionType)) {
       // We override the address level for these action types because we want to create individual
@@ -232,8 +230,8 @@ public class UacQidLinkBuilder {
         String.format("Can't find UAC QID '%s' for case", otherAllowableQuestionnaireType));
   }
 
-  private boolean isUacQidPreGeneratedActionType(ActionType actionType) {
-    return uacQidPreGeneratedActionTypes.contains(actionType);
+  private boolean isInitialContactActionType(ActionType actionType) {
+    return initialContactActionTypes.contains(actionType);
   }
 
   public static String calculateQuestionnaireType(

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -43,7 +43,10 @@ public class UacQidLinkBuilder {
           ActionType.SPG_IC12,
           ActionType.SPG_IC13,
           ActionType.SPG_IC14
-          // NO. DO NOT ADD ANYTHING TO THIS LIST. NOPE. NEVER.
+          // This list is only for INITIAL CONTACT letters/questionnaires. You should only add to
+          // it if you are certain that you are adding some new initial contact printed materials
+          // which is unlikely. For security reasons, initial contact UACs should never be mailed
+          // out a second time, because some respondents will have partially completed their EQs.
           );
 
   private static final String ADDRESS_LEVEL_ESTAB = "E";

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -59,8 +59,7 @@ public class PrintFileDtoBuilderTest {
   }
 
   @Test
-  public void
-      testReminderWotDoesNotNeedNoUacQidPairBecauseTheRespondentHasLaunchedButNotSubmittedAndHasDefinitelyNotLostTheirOriginalInitialContactLetterProbably() {
+  public void testReminderForRespondentLaunchedEqButNotSubmittedHasNoUacQid() {
     // Given
     EasyRandom easyRandom = new EasyRandom();
     Case testCaze = easyRandom.nextObject(Case.class);

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -59,7 +59,8 @@ public class PrintFileDtoBuilderTest {
   }
 
   @Test
-  public void testResponseDrivenReminder() {
+  public void
+      testReminderWotDoesNotNeedNoUacQidPairBecauseTheRespondentHasLaunchedButNotSubmittedAndHasDefinitelyNotLostTheirOriginalInitialContactLetterProbably() {
     // Given
     EasyRandom easyRandom = new EasyRandom();
     Case testCaze = easyRandom.nextObject(Case.class);
@@ -101,10 +102,10 @@ public class PrintFileDtoBuilderTest {
   }
 
   private PrintFileDto getExpectedPrintFileDto(
-      Case caze, ActionType actionType, boolean isResponseDrivenReminder) {
+      Case caze, ActionType actionType, boolean isReminderWithoutUacQid) {
     PrintFileDto printFileDto = new PrintFileDto();
 
-    if (!isResponseDrivenReminder) {
+    if (!isReminderWithoutUacQid) {
       printFileDto.setUac(ENGLISH_UAC);
       printFileDto.setQid(ENGLISH_QID);
       printFileDto.setUacWales(WELSH_UAC);

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -43,7 +43,7 @@ public class PrintFileDtoBuilderTest {
     Case testCaze = easyRandom.nextObject(Case.class);
     UacQidLinkBuilder uacQidBuilder = getQidUacBuilder();
 
-    PrintFileDto expectedPrintFileDto = getExpectedPrintFileDto(testCaze);
+    PrintFileDto expectedPrintFileDto = getExpectedPrintFileDto(testCaze, ActionType.ICHHQW, false);
     PrintFileDtoBuilder printFileDtoBuilder = new PrintFileDtoBuilder(uacQidBuilder);
 
     // When
@@ -53,6 +53,29 @@ public class PrintFileDtoBuilderTest {
             actionTypeToPackCodeMap.get(expectedActionType),
             BATCH_UUID,
             ActionType.ICHHQW);
+
+    // Then
+    assertThat(actualPrintFileDto).isEqualToComparingFieldByField(expectedPrintFileDto);
+  }
+
+  @Test
+  public void testResponseDrivenReminder() {
+    // Given
+    EasyRandom easyRandom = new EasyRandom();
+    Case testCaze = easyRandom.nextObject(Case.class);
+    UacQidLinkBuilder uacQidBuilder = getQidUacBuilder();
+
+    PrintFileDto expectedPrintFileDto =
+        getExpectedPrintFileDto(testCaze, ActionType.P_RL_1RL1A, true);
+    PrintFileDtoBuilder printFileDtoBuilder = new PrintFileDtoBuilder(uacQidBuilder);
+
+    // When
+    PrintFileDto actualPrintFileDto =
+        printFileDtoBuilder.buildPrintFileDto(
+            testCaze,
+            actionTypeToPackCodeMap.get(expectedActionType),
+            BATCH_UUID,
+            ActionType.P_RL_1RL1A);
 
     // Then
     assertThat(actualPrintFileDto).isEqualToComparingFieldByField(expectedPrintFileDto);
@@ -77,12 +100,16 @@ public class PrintFileDtoBuilderTest {
     return uacQidLinkBuilder;
   }
 
-  private PrintFileDto getExpectedPrintFileDto(Case caze) {
+  private PrintFileDto getExpectedPrintFileDto(
+      Case caze, ActionType actionType, boolean isResponseDrivenReminder) {
     PrintFileDto printFileDto = new PrintFileDto();
-    printFileDto.setUac(ENGLISH_UAC);
-    printFileDto.setQid(ENGLISH_QID);
-    printFileDto.setUacWales(WELSH_UAC);
-    printFileDto.setQidWales(WELSH_QID);
+
+    if (!isResponseDrivenReminder) {
+      printFileDto.setUac(ENGLISH_UAC);
+      printFileDto.setQid(ENGLISH_QID);
+      printFileDto.setUacWales(WELSH_UAC);
+      printFileDto.setQidWales(WELSH_QID);
+    }
 
     printFileDto.setCaseRef(caze.getCaseRef());
     printFileDto.setAddressLine1(caze.getAddressLine1());
@@ -93,7 +120,7 @@ public class PrintFileDtoBuilderTest {
 
     printFileDto.setBatchId(BATCH_UUID.toString());
     printFileDto.setPackCode(actionTypeToPackCodeMap.get(expectedActionType));
-    printFileDto.setActionType(ActionType.ICHHQW.toString());
+    printFileDto.setActionType(actionType.toString());
     printFileDto.setFieldCoordinatorId(caze.getFieldCoordinatorId());
     printFileDto.setFieldOfficerId(caze.getFieldOfficerId());
     printFileDto.setOrganisationName(caze.getOrganisationName());


### PR DESCRIPTION
# Motivation and Context:
"Initial contact" does not equal "reminder letter". IC != RL. Initial contact != reminder letter. IC != RL.

# What has changed?
Removed reminder letters from list of initial contact action types. They're the ones with "RL" in because RL means "reminder letter". Reminder letters are not initial contact. __Reminder__.

# How to test?
Create an action rule for initial contact... an initial contact letter is printed. Create an action rule for a reminder letter... a reminder letter is printed. Initial contact != reminder letter. IC != RL.

# Links:
Trello: https://trello.com/c/UmkTMHAD