### PR TITLE
(IC03.1/IC04.1) Generate CE UNIT Addressed ICL Print Files 

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -1,7 +1,7 @@
 package uk.gov.ons.census.action.builders;
 
 import static uk.gov.ons.census.action.model.dto.EventType.RM_UAC_CREATED;
-import static uk.gov.ons.census.action.utility.ActionTypeHelper.isCeIndividualActionType;
+import static uk.gov.ons.census.action.utility.ActionTypeHelper.isExpectedCapacityActionType;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -27,7 +27,7 @@ import uk.gov.ons.census.action.model.repository.UacQidLinkRepository;
 
 @Component
 public class UacQidLinkBuilder {
-  private static final Set<ActionType> initialContactActionTypes =
+  private static final Set<ActionType> initialContactNotExpectedCapacityActionTypes =
       Set.of(
           ActionType.ICHHQE,
           ActionType.ICHHQW,
@@ -37,15 +37,13 @@ public class UacQidLinkBuilder {
           ActionType.ICL4N,
           ActionType.CE1_IC01,
           ActionType.CE1_IC02,
-          ActionType.CE_IC03_1,
-          ActionType.CE_IC04_1,
           ActionType.SPG_IC11,
           ActionType.SPG_IC12,
           ActionType.SPG_IC13,
           ActionType.SPG_IC14
-          // This list is only for INITIAL CONTACT letters/questionnaires. You should only add to
-          // it if you are certain that you are adding some new initial contact printed materials
-          // which is unlikely. For security reasons, initial contact UACs should never be mailed
+          // This list is only for INITIAL CONTACT letters/questionnaires that are not part of expected capacity for
+          // the case. You should only add to it if you are certain that you are adding some new initial contact
+          // printed materials which is unlikely. For security reasons, initial contact UACs should never be mailed
           // out a second time, because some respondents will have partially completed their EQs.
           );
 
@@ -87,9 +85,9 @@ public class UacQidLinkBuilder {
   }
 
   public UacQidTuple getUacQidLinks(Case linkedCase, ActionType actionType) {
-    if (isInitialContactActionType(actionType)) {
+    if (isInitialContactNotExpectedCapacityActionType(actionType)) {
       return fetchExistingUacQidPairsForAction(linkedCase, actionType);
-    } else if (isCeIndividualActionType(actionType)) {
+    } else if (isExpectedCapacityActionType(actionType)) {
       // We override the address level for these action types because we want to create individual
       // uac qid pairs
       return createNewUacQidPairsForAction(linkedCase, actionType, "U");
@@ -233,8 +231,8 @@ public class UacQidLinkBuilder {
         String.format("Can't find UAC QID '%s' for case", otherAllowableQuestionnaireType));
   }
 
-  private boolean isInitialContactActionType(ActionType actionType) {
-    return initialContactActionTypes.contains(actionType);
+  private boolean isInitialContactNotExpectedCapacityActionType(ActionType actionType) {
+    return initialContactNotExpectedCapacityActionTypes.contains(actionType);
   }
 
   public static String calculateQuestionnaireType(

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -42,12 +42,10 @@ public class UacQidLinkBuilder {
           ActionType.SPG_IC13,
           ActionType.SPG_IC14
           // This list is only for INITIAL CONTACT letters/questionnaires that are not part of
-          // expected capacity for
-          // the case. You should only add to it if you are certain that you are adding some new
-          // initial contact
-          // printed materials which is unlikely. For security reasons, initial contact UACs should
-          // never be mailed
-          // out a second time, because some respondents will have partially completed their EQs.
+          // expected capacity for the case. You should only add to it if you are certain that you
+          // are adding some new initial contact printed materials which is unlikely. For security
+          // reasons, initial contact UACs should never be mailed out a second time, because some
+          // respondents will have partially completed their EQs.
           );
 
   private static final String ADDRESS_LEVEL_ESTAB = "E";

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -41,9 +41,12 @@ public class UacQidLinkBuilder {
           ActionType.SPG_IC12,
           ActionType.SPG_IC13,
           ActionType.SPG_IC14
-          // This list is only for INITIAL CONTACT letters/questionnaires that are not part of expected capacity for
-          // the case. You should only add to it if you are certain that you are adding some new initial contact
-          // printed materials which is unlikely. For security reasons, initial contact UACs should never be mailed
+          // This list is only for INITIAL CONTACT letters/questionnaires that are not part of
+          // expected capacity for
+          // the case. You should only add to it if you are certain that you are adding some new
+          // initial contact
+          // printed materials which is unlikely. For security reasons, initial contact UACs should
+          // never be mailed
           // out a second time, because some respondents will have partially completed their EQs.
           );
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -25,8 +25,12 @@ public enum ActionType {
   CE_IC06(ActionHandler.PRINTER, "D_CE4A_ICLS4"),
 
   // Individual addressed initial contact letters for CE Units
-  CE_IC03_1(ActionHandler.PRINTER, "D_ICA_ICLR1"),
-  CE_IC04_1(ActionHandler.PRINTER, "D_ICA_ICLR2B"),
+  CE_IC03_1(
+      ActionHandler.PRINTER,
+      "D_ICA_ICLR1"), // Individual ICL with UAC for England (Hand Delivery) Addressed
+  CE_IC04_1(
+      ActionHandler.PRINTER,
+      "D_ICA_ICLR2B"), // Individual ICL with UAC for Wales (Hand Delivery) Addressed
 
   // Initial contact letters for SPGs
   SPG_IC11(ActionHandler.PRINTER, "P_ICCE_ICL1"),

--- a/src/main/java/uk/gov/ons/census/action/poller/CaseProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/poller/CaseProcessor.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.census.action.poller;
 
-import static uk.gov.ons.census.action.utility.ActionTypeHelper.isCeIndividualActionType;
+import static uk.gov.ons.census.action.utility.ActionTypeHelper.isExpectedCapacityActionType;
 
 import java.util.UUID;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -59,7 +59,7 @@ public class CaseProcessor {
 
     int numOfMessagesToSend = 1;
 
-    if (isCeIndividualActionType(triggeredActionRule.getActionType())) {
+    if (isExpectedCapacityActionType(triggeredActionRule.getActionType())) {
       numOfMessagesToSend = caseToProcess.getCeExpectedCapacity();
     }
     for (int i = 0; i < numOfMessagesToSend; i++) {

--- a/src/main/java/uk/gov/ons/census/action/utility/ActionTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/action/utility/ActionTypeHelper.java
@@ -4,7 +4,7 @@ import java.util.Set;
 import uk.gov.ons.census.action.model.entity.ActionType;
 
 public class ActionTypeHelper {
-  private static final Set<ActionType> ceIndividualActionTypes =
+  private static final Set<ActionType> expectedCapacityActionTypes =
       Set.of(
           ActionType.CE_IC03,
           ActionType.CE_IC03_1,
@@ -16,7 +16,7 @@ public class ActionTypeHelper {
           ActionType.CE_IC09,
           ActionType.CE_IC10);
 
-  public static boolean isCeIndividualActionType(ActionType actionType) {
-    return ceIndividualActionTypes.contains(actionType);
+  public static boolean isExpectedCapacityActionType(ActionType actionType) {
+    return expectedCapacityActionTypes.contains(actionType);
   }
 }

--- a/src/main/java/uk/gov/ons/census/action/utility/ActionTypeHelper.java
+++ b/src/main/java/uk/gov/ons/census/action/utility/ActionTypeHelper.java
@@ -7,7 +7,9 @@ public class ActionTypeHelper {
   private static final Set<ActionType> ceIndividualActionTypes =
       Set.of(
           ActionType.CE_IC03,
+          ActionType.CE_IC03_1,
           ActionType.CE_IC04,
+          ActionType.CE_IC04_1,
           ActionType.CE_IC05,
           ActionType.CE_IC06,
           ActionType.CE_IC08,

--- a/src/test/java/uk/gov/ons/census/action/utility/ActionTypeHelperTest.java
+++ b/src/test/java/uk/gov/ons/census/action/utility/ActionTypeHelperTest.java
@@ -2,7 +2,7 @@ package uk.gov.ons.census.action.utility;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static uk.gov.ons.census.action.utility.ActionTypeHelper.isCeIndividualActionType;
+import static uk.gov.ons.census.action.utility.ActionTypeHelper.isExpectedCapacityActionType;
 
 import org.junit.Test;
 import uk.gov.ons.census.action.model.entity.ActionType;
@@ -11,14 +11,14 @@ public class ActionTypeHelperTest {
 
   @Test
   public void testIsCeIndividualActionTypeIsTrue() {
-    boolean testActionType = isCeIndividualActionType(ActionType.CE_IC03);
+    boolean testActionType = isExpectedCapacityActionType(ActionType.CE_IC03);
 
     assertTrue(testActionType);
   }
 
   @Test
   public void testIsCeIndividualActionTypeIsFalse() {
-    boolean testActionType = isCeIndividualActionType(ActionType.ICL1E);
+    boolean testActionType = isExpectedCapacityActionType(ActionType.ICL1E);
 
     assertFalse(testActionType);
   }


### PR DESCRIPTION
# Motivation and Context
These ActionTypes needed to be changed to generate and address line for each instance of expected response recorded against the unit whereas before they were not dependent on expected capacity

# What has changed
ActionTypes added to appropriate class
Refactored method names

# How to test?
Build with other repos on card and run ATs

# Links
https://trello.com/c/FPqeHTfQ/1046-ic031-i041-generate-ce-unit-addressed-icl-print-files-3
https://collaborate2.ons.gov.uk/confluence/display/SDC/RM+Census+Initial+Contact+Run+Book+-+2021
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=34832584