### PR TITLE
Individual response reminders

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -15,7 +15,9 @@ public class PrintFileDtoBuilder {
           ActionType.P_RL_1RL1A,
           ActionType.P_RL_1RL2BA,
           ActionType.P_RL_2RL1A,
-          ActionType.P_RL_2RL2BA
+          ActionType.P_RL_2RL2BA,
+          ActionType.P_RL_1IRL1,
+          ActionType.P_RL_1IRL2B
           // Adding to this list will result in no UAC being sent on the printed
           // letter/questionnaire. Please be certain of what you're doing before adding to it.
           );

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -71,10 +71,6 @@ public enum ActionType {
   P_RL_2RL2BA(ActionHandler.PRINTER),
 
   // Individual response reminders
-  // ATTENTION: these action types should never be processed by the action scheduler. The cases are
-  // the be selected manually. these types are exceptional in that they target HI cases. Action
-  // rules created for these action types must always have the 'has_triggered' flag set to 't' on
-  // creation so that the action scheduler does not attempt to trigger them itself.
   P_RL_1IRL1(ActionHandler.PRINTER),
   P_RL_1IRL2B(ActionHandler.PRINTER),
 

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -56,6 +56,28 @@ public enum ActionType {
   P_RL_2RL1_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for England addresses
   P_RL_2RL2B_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for Wales addresses
 
+  // Response driven interventions
+  P_RD_2RL1_1(ActionHandler.PRINTER), // Response driven reminder group 1 English
+  P_RD_2RL2B_1(ActionHandler.PRINTER), // Response driven reminder group 1 Welsh
+  P_RD_2RL1_2(ActionHandler.PRINTER), // Response driven reminder group 2 English
+  P_RD_2RL2B_2(ActionHandler.PRINTER), // Response driven reminder group 2 Welsh
+  P_RD_2RL1_3(ActionHandler.PRINTER), // Response driven reminder group 3 English
+  P_RD_2RL2B_3(ActionHandler.PRINTER), // Response driven reminder group 3 Welsh
+
+  // Response driven reminders for survey launched, no new UACs needed
+  P_RL_1RL1A(ActionHandler.PRINTER),
+  P_RL_1RL2BA(ActionHandler.PRINTER),
+  P_RL_2RL1A(ActionHandler.PRINTER),
+  P_RL_2RL2BA(ActionHandler.PRINTER),
+
+  // Individual response reminders
+  // ATTENTION: these action types should never be processed by the action scheduler. The cases are
+  // the be selected manually. these types are exceptional in that they target HI cases. Action
+  // rules created for these action types must always have the 'has_triggered' flag set to 't' on
+  // creation so that the action scheduler does not attempt to trigger them itself.
+  P_RL_1IRL1(ActionHandler.PRINTER),
+  P_RL_1IRL2B(ActionHandler.PRINTER),
+
   // Reminder questionnaires
   P_QU_H1(ActionHandler.PRINTER),
   P_QU_H2(ActionHandler.PRINTER),
@@ -70,23 +92,9 @@ public enum ActionType {
 
   P_OR_IX(ActionHandler.PRINTER), // Individual Response questionnaire print
 
-  P_ER_IL(ActionHandler.PRINTER), // Information leaflet
-
   P_UAC_IX(ActionHandler.PRINTER), // Individual response UAC print
 
-  //  response driven interventions
-  P_RD_2RL1_1(ActionHandler.PRINTER), // Response driven reminder group 1 English
-  P_RD_2RL2B_1(ActionHandler.PRINTER), // Response driven reminder group 1 Welsh
-  P_RD_2RL1_2(ActionHandler.PRINTER), // Response driven reminder group 2 English
-  P_RD_2RL2B_2(ActionHandler.PRINTER), // Response driven reminder group 2 Welsh
-  P_RD_2RL1_3(ActionHandler.PRINTER), // Response driven reminder group 3 English
-  P_RD_2RL2B_3(ActionHandler.PRINTER), // Response driven reminder group 3 Welsh
-
-  // response driven reminders for survey launched, no new UACs needed
-  P_RL_1RL1A(ActionHandler.PRINTER),
-  P_RL_1RL2BA(ActionHandler.PRINTER),
-  P_RL_2RL1A(ActionHandler.PRINTER),
-  P_RL_2RL2BA(ActionHandler.PRINTER);
+  P_ER_IL(ActionHandler.PRINTER); // Information leaflet
 
   private final ActionHandler handler;
   private final String packCode;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/CaseMetadata.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/CaseMetadata.java
@@ -6,4 +6,5 @@ import lombok.Data;
 public class CaseMetadata {
 
   private Boolean secureEstablishment;
+  private String channel;
 }


### PR DESCRIPTION
# Motivation and Context
The case metadata can now contain the channel of creation for HI cases.

# What has changed
* Add individual reminder action types 
* Update case metadata entity
* Add individual response codes to list of codes requiring no UAC

# How to test?
At AT's PR
Note to build action worker you need the branch of action scheduler built first
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/296
https://github.com/ONSdigital/census-rm-action-scheduler/pull/98

# Links
https://trello.com/c/Rc8d1RmE/983-reminders-individual-response-8