### PR TITLE
Address frame delta - Allow user-defined where clause for action rules

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -25,8 +25,7 @@ public class ActionRule {
   @Column private OffsetDateTime triggerDateTime;
 
   @Column private Boolean hasTriggered;
-
-  // This will be set to varchar(max) in the ddl
+  
   @Column(nullable = false, length = 100000)
   private String userDefinedWhereClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -2,8 +2,6 @@ package uk.gov.ons.census.action.model.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,7 +10,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import lombok.Data;
-import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
@@ -33,7 +30,6 @@ public class ActionRule {
 
   @Column private Boolean hasTriggered;
 
-  @Type(type = "jsonb")
-  @Column(columnDefinition = "jsonb", nullable = false)
-  private Map<String, List<String>> classifiers;
+  @Column(nullable = false)
+  private String userDefinedWhereClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import lombok.Data;
 
@@ -26,6 +27,7 @@ public class ActionRule {
 
   @Column private Boolean hasTriggered;
 
-  @Column(nullable = false, length = 100000)
-  private String userDefinedWhereClause;
+  @Lob
+  @Column(nullable = false)
+  private String classifiersClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.census.action.model.entity;
 
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import javax.persistence.Column;
@@ -10,11 +9,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import lombok.Data;
-import org.hibernate.annotations.TypeDef;
-import org.hibernate.annotations.TypeDefs;
 
 @Entity
-@TypeDefs({@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)})
 @Data
 public class ActionRule {
 
@@ -30,6 +26,7 @@ public class ActionRule {
 
   @Column private Boolean hasTriggered;
 
-  @Column(nullable = false)
+  // This will be set to varchar(max) in the ddl
+  @Column(nullable = false, length = 100000)
   private String userDefinedWhereClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -27,5 +27,5 @@ public class ActionRule {
   @Column private Boolean hasTriggered;
 
   @Column(nullable = false, length = 100000)
-  private String userDefinedWhereClause;
+  private String classifiersClause;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -25,7 +25,7 @@ public class ActionRule {
   @Column private OffsetDateTime triggerDateTime;
 
   @Column private Boolean hasTriggered;
-  
+
   @Column(nullable = false, length = 100000)
   private String userDefinedWhereClause;
 }

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -482,7 +482,7 @@ public class ChunkPollerIT {
     actionRule.setActionType(actionType);
     actionRule.setActionPlan(actionPlan);
 
-    actionRule.setUserDefinedWhereClause(" case_type != 'HI'");
+    actionRule.setClassifiersClause(" case_type != 'HI'");
 
     return actionRuleRepository.saveAndFlush(actionRule);
   }

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -482,7 +482,7 @@ public class ChunkPollerIT {
     actionRule.setActionType(actionType);
     actionRule.setActionPlan(actionPlan);
 
-    actionRule.setUserDefinedWhereClause("");
+    actionRule.setUserDefinedWhereClause(" case_type != 'HI'");
 
     return actionRuleRepository.saveAndFlush(actionRule);
   }

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -482,8 +482,7 @@ public class ChunkPollerIT {
     actionRule.setActionType(actionType);
     actionRule.setActionPlan(actionPlan);
 
-    Map<String, List<String>> classifiers = new HashMap<>();
-    actionRule.setClassifiers(classifiers);
+    actionRule.setUserDefinedWhereClause("");
 
     return actionRuleRepository.saveAndFlush(actionRule);
   }


### PR DESCRIPTION
# Motivation and Context:
<!--- Why is this change required? What problem does it solve? -->
We can now create action rules using a String which should resemble the end of a WHERE clause in SQL, e.g. `AND treatment_code IN ('abc', 'def')`. 

# What has changed?
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Renamed classifier and changed type

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See other related PRs

# Links:
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/TnldEmYZ/1023-address-frame-delta-generate-additional-initial-contact-files-13