### PR TITLE
classifierClause to use byte array

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -36,4 +36,8 @@ public class ActionRule {
   public void setClassifiersClause(String classifierClauseStr) {
     classifiersClause = classifierClauseStr.getBytes();
   }
+
+  public String getClassifiersClause() {
+    return new String(classifiersClause);
+  }
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionRule.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import lombok.Data;
+import org.hibernate.annotations.Type;
 
 @Entity
 @Data
@@ -28,6 +29,11 @@ public class ActionRule {
   @Column private Boolean hasTriggered;
 
   @Lob
+  @Type(type = "org.hibernate.type.BinaryType")
   @Column(nullable = false)
-  private String classifiersClause;
+  private byte[] classifiersClause;
+
+  public void setClassifiersClause(String classifierClauseStr) {
+    classifiersClause = classifierClauseStr.getBytes();
+  }
 }


### PR DESCRIPTION
# Motivation and Context:
Text classifiers column wasn't playing nicely

# What has changed?
Made column type a ByteA

# How to test?
With action-scheduler from ticket should work with master ATs

# Links:
https://trello.com/c/ye66Hup7/1159-make-classifierclause-a-varchar