### PR TITLE
Use UUID type for UUID data

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/CaseSelectedBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/CaseSelectedBuilder.java
@@ -15,7 +15,7 @@ import uk.gov.ons.census.action.model.dto.ResponseManagementEvent;
 @Component
 public class CaseSelectedBuilder {
   public ResponseManagementEvent buildPrintMessage(
-      UUID batchId, long caseRef, String packCode, String actionRuleId) {
+      UUID batchId, long caseRef, String packCode, UUID actionRuleId) {
     ResponseManagementEvent responseManagementEvent =
         buildEventWithoutPayload(EventType.PRINT_CASE_SELECTED);
     PrintCaseSelected printCaseSelected = new PrintCaseSelected();
@@ -35,7 +35,7 @@ public class CaseSelectedBuilder {
     FieldCaseSelected fieldCaseSelected = new FieldCaseSelected();
     responseManagementEvent.getPayload().setFieldCaseSelected(fieldCaseSelected);
 
-    fieldCaseSelected.setActionRuleId(actionRuleId.toString());
+    fieldCaseSelected.setActionRuleId(actionRuleId);
     fieldCaseSelected.setCaseRef(Long.parseLong(caseRef));
 
     return responseManagementEvent;

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -126,7 +126,7 @@ public class UacQidLinkBuilder {
   }
 
   private UacQidTuple fetchExistingUacQidPairsForAction(Case linkedCase, ActionType actionType) {
-    String caseId = linkedCase.getCaseId().toString();
+    UUID caseId = linkedCase.getCaseId();
 
     List<UacQidLink> uacQidLinks = uacQidLinkRepository.findByCaseId(caseId);
 

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -100,7 +100,7 @@ public class UacQidLinkBuilder {
   public UacQidLink createNewUacQidPair(Case linkedCase, String questionnaireType) {
     UacQidDTO newUacQidPair = uacQidCache.getUacQidPair(Integer.parseInt(questionnaireType));
     UacQidCreated uacQidCreated = new UacQidCreated();
-    uacQidCreated.setCaseId(linkedCase.getCaseId().toString());
+    uacQidCreated.setCaseId(linkedCase.getCaseId());
     uacQidCreated.setQid(newUacQidPair.getQid());
     uacQidCreated.setUac(newUacQidPair.getUac());
 
@@ -121,7 +121,7 @@ public class UacQidLinkBuilder {
     UacQidLink uacQidLink = new UacQidLink();
     uacQidLink.setQid(newUacQidPair.getQid());
     uacQidLink.setUac(newUacQidPair.getUac());
-    uacQidLink.setCaseId(linkedCase.getCaseId().toString());
+    uacQidLink.setCaseId(linkedCase.getCaseId());
     return uacQidLink;
   }
 

--- a/src/main/java/uk/gov/ons/census/action/model/dto/FieldCaseSelected.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/FieldCaseSelected.java
@@ -1,9 +1,10 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class FieldCaseSelected {
   private long caseRef;
-  private String actionRuleId;
+  private UUID actionRuleId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/PrintCaseSelected.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/PrintCaseSelected.java
@@ -1,11 +1,12 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class PrintCaseSelected {
   private long caseRef;
   private String packCode;
-  private String actionRuleId;
+  private UUID actionRuleId;
   private String batchId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/UacQidCreated.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/UacQidCreated.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class UacQidCreated {
   private String uac;
   private String qid;
-  private String caseId;
+  private UUID caseId;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/Case.java
@@ -83,9 +83,9 @@ public class Case {
 
   @Column private Integer ceActualResponses;
 
-  @Column private String collectionExerciseId;
+  @Column private UUID collectionExerciseId;
 
-  @Column private String actionPlanId;
+  @Column private UUID actionPlanId;
 
   @Column(name = "receipt_received", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean receiptReceived;

--- a/src/main/java/uk/gov/ons/census/action/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/UacQidLink.java
@@ -18,7 +18,7 @@ public class UacQidLink {
 
   @Column private String uac;
 
-  @Column private String caseId;
+  @Column private UUID caseId;
 
   @Column private boolean active;
 }

--- a/src/main/java/uk/gov/ons/census/action/model/repository/UacQidLinkRepository.java
+++ b/src/main/java/uk/gov/ons/census/action/model/repository/UacQidLinkRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.census.action.model.entity.UacQidLink;
 
 public interface UacQidLinkRepository extends JpaRepository<UacQidLink, UUID> {
-  List<UacQidLink> findByCaseId(String caseId);
+  List<UacQidLink> findByCaseId(UUID caseId);
 }

--- a/src/main/java/uk/gov/ons/census/action/poller/CaseProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/poller/CaseProcessor.java
@@ -78,7 +78,7 @@ public class CaseProcessor {
             caseToProcess.getBatchId(),
             caseToProcess.getCaze().getCaseRef(),
             triggeredActionRule.getActionType().getPackCode(),
-            triggeredActionRule.getId().toString());
+            triggeredActionRule.getId());
 
     rabbitTemplate.convertAndSend(actionCaseExchange, "", printCaseSelected);
   }

--- a/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
@@ -56,13 +56,13 @@ public class UacQidLinkBuilderTest {
 
     List<UacQidLink> uacQidLinks = new ArrayList<>();
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacEng);
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
 
     uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacWal);
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
@@ -79,13 +79,13 @@ public class UacQidLinkBuilderTest {
     UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
-    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
+    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
     assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
 
     UacQidLink actualWalesdUacQidLink = uacQidTuple.getUacQidLinkWales().get();
-    assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
+    assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualWalesdUacQidLink.getQid()).isEqualTo(qidWal);
     assertThat(actualWalesdUacQidLink.getUac()).isEqualTo(uacWal);
     assertThat(actualWalesdUacQidLink.isActive()).isEqualTo(false);
@@ -105,13 +105,13 @@ public class UacQidLinkBuilderTest {
 
     List<UacQidLink> uacQidLinks = new ArrayList<>();
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacEng);
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
 
     uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacWal);
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
@@ -139,13 +139,13 @@ public class UacQidLinkBuilderTest {
     UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.SPG_IC14);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
-    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
+    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
     assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
 
     UacQidLink actualWalesdUacQidLink = uacQidTuple.getUacQidLinkWales().get();
-    assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
+    assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualWalesdUacQidLink.getQid()).isEqualTo(qidWal);
     assertThat(actualWalesdUacQidLink.getUac()).isEqualTo(uacWal);
     assertThat(actualWalesdUacQidLink.isActive()).isEqualTo(false);
@@ -165,13 +165,13 @@ public class UacQidLinkBuilderTest {
 
     List<UacQidLink> uacQidLinks = new ArrayList<>();
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacEng);
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
 
     uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacWal);
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
@@ -199,13 +199,13 @@ public class UacQidLinkBuilderTest {
     UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.CE_IC10);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
-    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
+    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
     assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
 
     UacQidLink actualWalesdUacQidLink = uacQidTuple.getUacQidLinkWales().get();
-    assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
+    assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualWalesdUacQidLink.getQid()).isEqualTo(qidWal);
     assertThat(actualWalesdUacQidLink.getUac()).isEqualTo(uacWal);
     assertThat(actualWalesdUacQidLink.isActive()).isEqualTo(false);
@@ -220,7 +220,7 @@ public class UacQidLinkBuilderTest {
 
     List<UacQidLink> uacQidLinks = new ArrayList<>();
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacEng);
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
@@ -234,7 +234,7 @@ public class UacQidLinkBuilderTest {
     UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICL1E);
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
-    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId().toString());
+    assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
     assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
@@ -313,13 +313,13 @@ public class UacQidLinkBuilderTest {
 
     List<UacQidLink> uacQidLinks = new ArrayList<>();
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacEng);
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
 
     uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacWal);
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
@@ -351,7 +351,7 @@ public class UacQidLinkBuilderTest {
 
     List<UacQidLink> uacQidLinks = new ArrayList<>();
     UacQidLink uacQidLink = new UacQidLink();
-    uacQidLink.setCaseId(testCase.getCaseId().toString());
+    uacQidLink.setCaseId(testCase.getCaseId());
     uacQidLink.setUac(uacEng);
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
@@ -446,8 +446,7 @@ public class UacQidLinkBuilderTest {
     verify(uacQidCache).getUacQidPair(eq(Integer.parseInt(ENGLISH_QUESTIONNAIRE_TYPE)));
     assertThat(actualUacQidTuple.getUacQidLink())
         .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
-    assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+    assertThat(actualUacQidTuple.getUacQidLink().getCaseId()).isEqualTo(linkedCase.getCaseId());
 
     ArgumentCaptor<ResponseManagementEvent> rmEventArgCaptor =
         ArgumentCaptor.forClass(ResponseManagementEvent.class);
@@ -458,7 +457,7 @@ public class UacQidLinkBuilderTest {
     assertThat(rmEvent.getPayload().getUacQidCreated().getQid()).isEqualTo(uacQidDTO.getQid());
     assertThat(rmEvent.getPayload().getUacQidCreated().getUac()).isEqualTo(uacQidDTO.getUac());
     assertThat(rmEvent.getPayload().getUacQidCreated().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+        .isEqualTo(linkedCase.getCaseId());
   }
 
   @Test
@@ -480,8 +479,7 @@ public class UacQidLinkBuilderTest {
     verify(uacQidCache).getUacQidPair(eq(Integer.parseInt(ENGLISH_QUESTIONNAIRE_TYPE)));
     assertThat(actualUacQidTuple.getUacQidLink())
         .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
-    assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+    assertThat(actualUacQidTuple.getUacQidLink().getCaseId()).isEqualTo(linkedCase.getCaseId());
 
     ArgumentCaptor<ResponseManagementEvent> rmEventArgCaptor =
         ArgumentCaptor.forClass(ResponseManagementEvent.class);
@@ -492,7 +490,7 @@ public class UacQidLinkBuilderTest {
     assertThat(rmEvent.getPayload().getUacQidCreated().getQid()).isEqualTo(uacQidDTO.getQid());
     assertThat(rmEvent.getPayload().getUacQidCreated().getUac()).isEqualTo(uacQidDTO.getUac());
     assertThat(rmEvent.getPayload().getUacQidCreated().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+        .isEqualTo(linkedCase.getCaseId());
   }
 
   @Test
@@ -519,13 +517,12 @@ public class UacQidLinkBuilderTest {
     verify(uacQidCache).getUacQidPair(eq(Integer.parseInt(WALES_IN_WELSH_QUESTIONNAIRE_TYPE)));
     assertThat(actualUacQidTuple.getUacQidLink())
         .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
-    assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+    assertThat(actualUacQidTuple.getUacQidLink().getCaseId()).isEqualTo(linkedCase.getCaseId());
     assertThat(actualUacQidTuple.getUacQidLinkWales().isPresent()).isTrue();
     assertThat(actualUacQidTuple.getUacQidLinkWales().get())
         .isEqualToComparingOnlyGivenFields(welshUacQidDTO, "uac", "qid");
     assertThat(actualUacQidTuple.getUacQidLinkWales().get().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+        .isEqualTo(linkedCase.getCaseId());
 
     verify(rabbitTemplate, times(2))
         .convertAndSend(eq(UAC_QID_CREATED_EXCHAGE), eq(""), any(ResponseManagementEvent.class));
@@ -559,13 +556,12 @@ public class UacQidLinkBuilderTest {
         .getUacQidPair(eq(Integer.parseInt(WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE_CE_CASES)));
     assertThat(actualUacQidTuple.getUacQidLink())
         .isEqualToComparingOnlyGivenFields(uacQidDTO, "uac", "qid");
-    assertThat(actualUacQidTuple.getUacQidLink().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+    assertThat(actualUacQidTuple.getUacQidLink().getCaseId()).isEqualTo(linkedCase.getCaseId());
     assertThat(actualUacQidTuple.getUacQidLinkWales().isPresent()).isTrue();
     assertThat(actualUacQidTuple.getUacQidLinkWales().get())
         .isEqualToComparingOnlyGivenFields(welshUacQidDTO, "uac", "qid");
     assertThat(actualUacQidTuple.getUacQidLinkWales().get().getCaseId())
-        .isEqualTo(linkedCase.getCaseId().toString());
+        .isEqualTo(linkedCase.getCaseId());
 
     verify(rabbitTemplate, times(2))
         .convertAndSend(eq(UAC_QID_CREATED_EXCHAGE), eq(""), any(ResponseManagementEvent.class));

--- a/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
@@ -67,8 +67,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     testCase.setTreatmentCode(
         HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX
@@ -116,8 +115,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     UacQidDTO uacQidDTOEngland = new UacQidDTO();
     uacQidDTOEngland.setUac(uacEng);
@@ -176,8 +174,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     UacQidDTO uacQidDTOEngland = new UacQidDTO();
     uacQidDTOEngland.setUac(uacEng);
@@ -225,8 +222,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     testCase.setTreatmentCode("NotWelshTreatmentCode");
 
@@ -262,8 +258,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     // When
     uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
@@ -292,8 +287,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     // When
     uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
@@ -327,8 +321,7 @@ public class UacQidLinkBuilderTest {
     // add the 3rd and fatal Link
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     testCase.setTreatmentCode(
         HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX
@@ -356,8 +349,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidEng);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId().toString()))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     testCase.setTreatmentCode(
         HOUSEHOLD_INITIAL_CONTACT_QUESTIONNAIRE_TREATMENT_CODE_PREFIX
@@ -381,7 +373,7 @@ public class UacQidLinkBuilderTest {
     Case testCase = easyRandom.nextObject(Case.class);
     testCase.setTreatmentCode("HH_QF2R1W");
 
-    when(uacQidLinkRepository.findByCaseId(eq(testCase.getCaseId().toString())))
+    when(uacQidLinkRepository.findByCaseId(eq(testCase.getCaseId())))
         .thenReturn(Collections.EMPTY_LIST);
 
     // When
@@ -417,8 +409,7 @@ public class UacQidLinkBuilderTest {
     uacQidLink.setQid(qidWal);
     uacQidLinks.add(uacQidLink);
 
-    when(uacQidLinkRepository.findByCaseId(eq(testCase.getCaseId().toString())))
-        .thenReturn(uacQidLinks);
+    when(uacQidLinkRepository.findByCaseId(eq(testCase.getCaseId()))).thenReturn(uacQidLinks);
 
     // When
     uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);

--- a/src/test/java/uk/gov/ons/census/action/poller/CaseProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/CaseProcessorTest.java
@@ -65,7 +65,7 @@ public class CaseProcessorTest {
     when(printFileDtoBuilder.buildPrintFileDto(any(), any(), any(), any()))
         .thenReturn(printFileDto);
     when(caseSelectedBuilder.buildPrintMessage(
-            any(UUID.class), anyLong(), anyString(), anyString()))
+            any(UUID.class), anyLong(), anyString(), any(UUID.class)))
         .thenReturn(responseManagementEvent);
 
     // When
@@ -80,7 +80,7 @@ public class CaseProcessorTest {
             eq(caseToProcess.getBatchId()),
             eq(caseToProcess.getCaze().getCaseRef()),
             eq(printFileDto.getPackCode()),
-            eq(actionRule.getId().toString()));
+            eq(actionRule.getId()));
     verify(rabbitTemplate)
         .convertAndSend(
             eq(outboundExchange),
@@ -111,7 +111,7 @@ public class CaseProcessorTest {
     when(printFileDtoBuilder.buildPrintFileDto(any(), any(), any(), any()))
         .thenReturn(printFileDto);
     when(caseSelectedBuilder.buildPrintMessage(
-            any(UUID.class), anyLong(), anyString(), anyString()))
+            any(UUID.class), anyLong(), anyString(), any(UUID.class)))
         .thenReturn(responseManagementEvent);
 
     // When
@@ -126,7 +126,7 @@ public class CaseProcessorTest {
             eq(caseToProcess.getBatchId()),
             eq(caseToProcess.getCaze().getCaseRef()),
             eq(printFileDto.getPackCode()),
-            eq(actionRule.getId().toString()));
+            eq(actionRule.getId()));
     verify(rabbitTemplate, times(5))
         .convertAndSend(
             eq(outboundExchange),

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -115,7 +115,7 @@ public class ChunkPollerIT {
       assertThat(actualRmUacQidCreateEvent.getEvent().getType())
           .isEqualTo(EventType.RM_UAC_CREATED);
       assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getCaseId())
-          .isEqualTo(randomCase.getCaseId().toString());
+          .isEqualTo(randomCase.getCaseId());
       assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getQid())
           .isEqualTo(uacQidDto.getQid());
       assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getUac())
@@ -128,7 +128,7 @@ public class ChunkPollerIT {
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getCaseRef())
           .isEqualTo(randomCase.getCaseRef());
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getActionRuleId())
-          .isEqualTo(actionRule.getId().toString());
+          .isEqualTo(actionRule.getId());
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getPackCode())
           .isEqualTo("P_RL_1RL1_1");
 
@@ -188,7 +188,7 @@ public class ChunkPollerIT {
             objectMapper.readValue(actualUacQidCreateMessage, ResponseManagementEvent.class);
         assertThat(actualRmEvent.getEvent().getType()).isEqualTo(EventType.RM_UAC_CREATED);
         assertThat(actualRmEvent.getPayload().getUacQidCreated().getCaseId())
-            .isEqualTo(randomCase.getCaseId().toString());
+            .isEqualTo(randomCase.getCaseId());
 
         if (actualRmEvent.getPayload().getUacQidCreated().getQid().startsWith("02")) {
           actualRmUacQidCreateEvent = actualRmEvent;
@@ -217,7 +217,7 @@ public class ChunkPollerIT {
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getCaseRef())
           .isEqualTo(randomCase.getCaseRef());
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getActionRuleId())
-          .isEqualTo(actionRule.getId().toString());
+          .isEqualTo(actionRule.getId());
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getPackCode())
           .isEqualTo("P_QU_H2");
 
@@ -275,7 +275,7 @@ public class ChunkPollerIT {
       assertThat(actualRmEvent.getPayload().getFieldCaseSelected().getCaseRef())
           .isEqualTo(randomCase.getCaseRef());
       assertThat(actualRmEvent.getPayload().getFieldCaseSelected().getActionRuleId())
-          .isEqualTo(actionRule.getId().toString());
+          .isEqualTo(actionRule.getId());
 
       FieldworkFollowup actualFieldworkFollowup =
           objectMapper.readValue(actualMessage, FieldworkFollowup.class);
@@ -343,7 +343,7 @@ public class ChunkPollerIT {
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getCaseRef())
           .isEqualTo(randomCase.getCaseRef());
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getActionRuleId())
-          .isEqualTo(actionRule.getId().toString());
+          .isEqualTo(actionRule.getId());
       assertThat(actualRmEvent.getPayload().getPrintCaseSelected().getPackCode())
           .isEqualTo(ActionType.CE_IC03.getPackCode());
 
@@ -354,7 +354,7 @@ public class ChunkPollerIT {
         assertThat(actualRmUacQidCreateEvent.getEvent().getType())
             .isEqualTo(EventType.RM_UAC_CREATED);
         assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getCaseId())
-            .isEqualTo(randomCase.getCaseId().toString());
+            .isEqualTo(randomCase.getCaseId());
         assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getQid())
             .isEqualTo(uacQidDto.getQid());
         assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getUac())
@@ -404,7 +404,7 @@ public class ChunkPollerIT {
       assertThat(actualRmUacQidCreateEvent.getEvent().getType())
           .isEqualTo(EventType.RM_UAC_CREATED);
       assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getCaseId())
-          .isEqualTo(randomCase.getCaseId().toString());
+          .isEqualTo(randomCase.getCaseId());
       assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getQid())
           .isEqualTo(uacQidDto.getQid());
       assertThat(actualRmUacQidCreateEvent.getPayload().getUacQidCreated().getUac())
@@ -490,7 +490,7 @@ public class ChunkPollerIT {
 
   private Case setUpCase(ActionPlan actionPlan, Integer ceExpectedCapacity) {
     Case randomCase = easyRandom.nextObject(Case.class);
-    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setActionPlanId(actionPlan.getId());
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(null);
     randomCase.setAddressInvalid(false);
@@ -507,7 +507,7 @@ public class ChunkPollerIT {
 
   private Case setUpWelshCase(ActionPlan actionPlan, Integer ceExpectedCapacity) {
     Case randomCase = easyRandom.nextObject(Case.class);
-    randomCase.setActionPlanId(actionPlan.getId().toString());
+    randomCase.setActionPlanId(actionPlan.getId());
     randomCase.setReceiptReceived(false);
     randomCase.setRefusalReceived(null);
     randomCase.setAddressInvalid(false);


### PR DESCRIPTION
# Motivation and Context
Use UUID data type to hold UUID data

# What has changed
Updated entity, dto and tests

# How to test?
- Build it and run it against the acceptance tests (master), with `use-UUID-type-for-UUId-data` branches of DDL, case-processor, action-scheduler, action-worker and action-processor.

# Links
- https://trello.com/c/r9qwqhaS