### PR TITLE
adding new reminder pack codes

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -19,7 +19,7 @@ public class PrintFileDtoBuilder {
           ActionType.P_RL_1IRL2B,
           ActionType.P_RL_1IRL1,
           ActionType.P_RL_1RL4
-              // Adding to this list will result in no UAC being sent on the printed
+          // Adding to this list will result in no UAC being sent on the printed
           // letter/questionnaire. Please be certain of what you're doing before adding to it.
           );
   private final UacQidLinkBuilder uacQidLinkBuilder;

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -20,7 +20,7 @@ public class PrintFileDtoBuilder {
           ActionType.P_RL_1IRL2B,
           ActionType.P_RL_1RL1B,
           ActionType.P_RL_1RL2BB,
-          ActionType.P_RL_1RL4A
+          ActionType.P_RL_1RL4
           // Adding to this list will result in no UAC being sent on the printed
           // letter/questionnaire. Please be certain of what you're doing before adding to it.
           );

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -17,7 +17,9 @@ public class PrintFileDtoBuilder {
           ActionType.P_RL_2RL1A,
           ActionType.P_RL_2RL2BA,
           ActionType.P_RL_1IRL1,
-          ActionType.P_RL_1IRL2B
+          ActionType.P_RL_1IRL2B,
+          ActionType.P_RL_1RL1B,
+          ActionType.P_RL_1RL2BB
           // Adding to this list will result in no UAC being sent on the printed
           // letter/questionnaire. Please be certain of what you're doing before adding to it.
           );

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -14,14 +14,10 @@ public class PrintFileDtoBuilder {
       Set.of(
           ActionType.P_RL_1RL1A,
           ActionType.P_RL_1RL2BA,
-          ActionType.P_RL_2RL1,
-          ActionType.P_RL_2RL2B,
           ActionType.P_RL_2RL1A,
           ActionType.P_RL_2RL2BA,
           ActionType.P_RL_1IRL1,
           ActionType.P_RL_1IRL2B,
-          ActionType.P_RL_1RL1B,
-          ActionType.P_RL_1RL2BB,
           ActionType.P_RL_1RL4
           // Adding to this list will result in no UAC being sent on the printed
           // letter/questionnaire. Please be certain of what you're doing before adding to it.

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -12,6 +12,7 @@ import uk.gov.ons.census.action.model.entity.Case;
 public class PrintFileDtoBuilder {
   private static final Set<ActionType> doesNotRequireUacQidActionTypes =
       Set.of(
+          ActionType.P_RL_1RL1_1,
           ActionType.P_RL_1RL1A,
           ActionType.P_RL_1RL2BA,
           ActionType.P_RL_2RL1A,

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -19,7 +19,8 @@ public class PrintFileDtoBuilder {
           ActionType.P_RL_1IRL1,
           ActionType.P_RL_1IRL2B,
           ActionType.P_RL_1RL1B,
-          ActionType.P_RL_1RL2BB
+          ActionType.P_RL_1RL2BB,
+          ActionType.P_RL_1RL4A
           // Adding to this list will result in no UAC being sent on the printed
           // letter/questionnaire. Please be certain of what you're doing before adding to it.
           );

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -16,7 +16,6 @@ public class PrintFileDtoBuilder {
           ActionType.P_RL_1RL2BA,
           ActionType.P_RL_2RL1A,
           ActionType.P_RL_2RL2BA,
-          ActionType.P_RL_1IRL1,
           ActionType.P_RL_1IRL2B,
           ActionType.P_RL_1RL4
           // Adding to this list will result in no UAC being sent on the printed

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -12,12 +12,12 @@ import uk.gov.ons.census.action.model.entity.Case;
 public class PrintFileDtoBuilder {
   private static final Set<ActionType> doesNotRequireUacQidActionTypes =
       Set.of(
-          ActionType.P_RL_1RL1_1,
           ActionType.P_RL_1RL1A,
           ActionType.P_RL_1RL2BA,
           ActionType.P_RL_2RL1A,
           ActionType.P_RL_2RL2BA,
           ActionType.P_RL_1IRL2B,
+          ActionType.P_RL_1IRL1,
           ActionType.P_RL_1RL4
           // Adding to this list will result in no UAC being sent on the printed
           // letter/questionnaire. Please be certain of what you're doing before adding to it.

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -14,6 +14,8 @@ public class PrintFileDtoBuilder {
       Set.of(
           ActionType.P_RL_1RL1A,
           ActionType.P_RL_1RL2BA,
+          ActionType.P_RL_2RL1,
+          ActionType.P_RL_2RL2B,
           ActionType.P_RL_2RL1A,
           ActionType.P_RL_2RL2BA,
           ActionType.P_RL_1IRL1,

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -74,9 +74,10 @@ public enum ActionType {
   P_RL_1IRL1(ActionHandler.PRINTER),
   P_RL_1IRL2B(ActionHandler.PRINTER),
 
-  // Reminder letters for paper first households who have not authenticated (nor submitted paper questionnaire)
-  P_RL_1RL1B(ActionHandler.PRINTER),
-  P_RL_1RL2BB(ActionHandler.PRINTER),
+  // Reminder letters for paper first households who have not EQ authenticated (nor submitted paper questionnaire)
+  P_RL_1RL1B(ActionHandler.PRINTER),   // paper first reminders for english households
+  P_RL_1RL2BB(ActionHandler.PRINTER),  // paper first reminders for welsh households
+  P_RL_1RL4A(ActionHandler.PRINTER),   // paper first reminders for irish households
 
   // Reminder questionnaires
   P_QU_H1(ActionHandler.PRINTER),

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -74,6 +74,10 @@ public enum ActionType {
   P_RL_1IRL1(ActionHandler.PRINTER),
   P_RL_1IRL2B(ActionHandler.PRINTER),
 
+  // Reminder letters for paper first households who have not authenticated (nor submitted paper questionnaire)
+  P_RL_1RL1B(ActionHandler.PRINTER),
+  P_RL_1RL2BB(ActionHandler.PRINTER),
+
   // Reminder questionnaires
   P_QU_H1(ActionHandler.PRINTER),
   P_QU_H2(ActionHandler.PRINTER),

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -73,6 +73,8 @@ public enum ActionType {
   // Individual response reminders
   P_RL_1IRL1(ActionHandler.PRINTER),
   P_RL_1IRL2B(ActionHandler.PRINTER),
+  P_RL_2RL1(ActionHandler.PRINTER),
+  P_RL_2RL2B(ActionHandler.PRINTER),
 
   // Reminder letters for paper first households who have not EQ authenticated (nor submitted paper
   // questionnaire)

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -74,10 +74,11 @@ public enum ActionType {
   P_RL_1IRL1(ActionHandler.PRINTER),
   P_RL_1IRL2B(ActionHandler.PRINTER),
 
-  // Reminder letters for paper first households who have not EQ authenticated (nor submitted paper questionnaire)
-  P_RL_1RL1B(ActionHandler.PRINTER),   // paper first reminders for english households
-  P_RL_1RL2BB(ActionHandler.PRINTER),  // paper first reminders for welsh households
-  P_RL_1RL4A(ActionHandler.PRINTER),   // paper first reminders for irish households
+  // Reminder letters for paper first households who have not EQ authenticated (nor submitted paper
+  // questionnaire)
+  P_RL_1RL1B(ActionHandler.PRINTER), // paper first reminders for english households
+  P_RL_1RL2BB(ActionHandler.PRINTER), // paper first reminders for welsh households
+  P_RL_1RL4A(ActionHandler.PRINTER), // paper first reminders for irish households
 
   // Reminder questionnaires
   P_QU_H1(ActionHandler.PRINTER),

--- a/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
+++ b/src/main/java/uk/gov/ons/census/action/model/entity/ActionType.java
@@ -48,39 +48,16 @@ public enum ActionType {
   P_RL_1RL2B_1(
       ActionHandler
           .PRINTER), // 1st Reminder, Letter - for Wales addresses (bilingual Welsh and English)
-  P_RL_1RL4(ActionHandler.PRINTER), // 1st Reminder, Letter - for Ireland addresses
   P_RL_1RL1_2(ActionHandler.PRINTER), // 2nd Reminder, Letter - for England addresses
   P_RL_1RL2B_2(
       ActionHandler
           .PRINTER), // 2nd Reminder, Letter - for Wales addresses (bilingual Welsh and English)
+
+  P_RL_2RL1(ActionHandler.PRINTER), // 2nd Reminder, Letter - for England addresses
+  P_RL_2RL4(ActionHandler.PRINTER), // 2nd Reminder, Letter - for Irish addresses
+  P_RL_2RL2B(ActionHandler.PRINTER), // 2nd Reminder, Letter - for Wales addresses
   P_RL_2RL1_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for England addresses
   P_RL_2RL2B_3a(ActionHandler.PRINTER), // 3rd Reminder, Letter - for Wales addresses
-
-  // Response driven interventions
-  P_RD_2RL1_1(ActionHandler.PRINTER), // Response driven reminder group 1 English
-  P_RD_2RL2B_1(ActionHandler.PRINTER), // Response driven reminder group 1 Welsh
-  P_RD_2RL1_2(ActionHandler.PRINTER), // Response driven reminder group 2 English
-  P_RD_2RL2B_2(ActionHandler.PRINTER), // Response driven reminder group 2 Welsh
-  P_RD_2RL1_3(ActionHandler.PRINTER), // Response driven reminder group 3 English
-  P_RD_2RL2B_3(ActionHandler.PRINTER), // Response driven reminder group 3 Welsh
-
-  // Response driven reminders for survey launched, no new UACs needed
-  P_RL_1RL1A(ActionHandler.PRINTER),
-  P_RL_1RL2BA(ActionHandler.PRINTER),
-  P_RL_2RL1A(ActionHandler.PRINTER),
-  P_RL_2RL2BA(ActionHandler.PRINTER),
-
-  // Individual response reminders
-  P_RL_1IRL1(ActionHandler.PRINTER),
-  P_RL_1IRL2B(ActionHandler.PRINTER),
-  P_RL_2RL1(ActionHandler.PRINTER),
-  P_RL_2RL2B(ActionHandler.PRINTER),
-
-  // Reminder letters for paper first households who have not EQ authenticated (nor submitted paper
-  // questionnaire)
-  P_RL_1RL1B(ActionHandler.PRINTER), // paper first reminders for english households
-  P_RL_1RL2BB(ActionHandler.PRINTER), // paper first reminders for welsh households
-  P_RL_1RL4A(ActionHandler.PRINTER), // paper first reminders for irish households
 
   // Reminder questionnaires
   P_QU_H1(ActionHandler.PRINTER),
@@ -99,9 +76,37 @@ public enum ActionType {
 
   P_UAC_IX(ActionHandler.PRINTER), // Individual response UAC print
 
-  P_UAC_CX(ActionHandler.PRINTER), // CE UAC via paper
+  P_ER_IL(ActionHandler.PRINTER), // Information leaflet
 
-  P_ER_IL(ActionHandler.PRINTER); // Information leaflet
+  P_UAC_CX(ActionHandler.PRINTER), // CE Unique Access Codes via paper
+
+  P_RL_3RL1(ActionHandler.PRINTER), // 3rd Reminder, Letter - for England addresses
+  P_RL_3RL2B(ActionHandler.PRINTER), // 3rd Reminder, Letter - for Wales addresses
+
+  // Response driven interventions
+  P_RD_2RL1_1(ActionHandler.PRINTER), // Response driven reminder group 1 English
+  P_RD_2RL2B_1(ActionHandler.PRINTER), // Response driven reminder group 1 Welsh
+  P_RD_2RL1_2(ActionHandler.PRINTER), // Response driven reminder group 2 English
+  P_RD_2RL2B_2(ActionHandler.PRINTER), // Response driven reminder group 2 Welsh
+  P_RD_2RL1_3(ActionHandler.PRINTER), // Response driven reminder group 3 English
+  P_RD_2RL2B_3(ActionHandler.PRINTER), // Response driven reminder group 3 Welsh
+
+  // Reminders for survey launched, no new UACs needed
+  P_RL_1RL4(ActionHandler.PRINTER), // 1st Reminder, Letter - for Ireland addresses
+  P_RL_1RL1A(ActionHandler.PRINTER),
+  P_RL_1RL2BA(ActionHandler.PRINTER),
+  P_RL_2RL1A(ActionHandler.PRINTER),
+  P_RL_2RL2BA(ActionHandler.PRINTER),
+
+  // Individual response reminders
+  P_RL_1IRL1(ActionHandler.PRINTER),
+  P_RL_1IRL2B(ActionHandler.PRINTER),
+
+  // Reminder letters for paper first households who have not EQ authenticated (nor submitted paper
+  // questionnaire)
+  P_RL_1RL1B(ActionHandler.PRINTER), // paper first reminders for english households
+  P_RL_1RL2BB(ActionHandler.PRINTER), // paper first reminders for welsh households
+  P_RL_1RL4A(ActionHandler.PRINTER); // paper first reminders for irish households
 
   private final ActionHandler handler;
   private final String packCode;


### PR DESCRIPTION
# Motivation and Context:
Adding two new reminder pack codes

# What has changed?
Two new pack codes have been added mainly as enums throughout the software.
