### PR TITLE
Hack around the problem with retry messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
-      <version>2.24.0</version>
+      <version>2.27.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ queueconfig:
   action-case-exchange: action-case-exchange
   uac-qid-created-exchange: uac-qid-created-exchange
   consumers: 50
-  retry-attempts: 3
+  retry-attempts: 1
   retry-delay: 1000 #milliseconds
 
 healthcheck:
@@ -60,7 +60,7 @@ uacservice:
 
   uacqid-cache-min: 500
   uacqid-fetch-count: 1000
-  uacqid-get-timeout: 5   #seconds
+  uacqid-get-timeout: 60   #seconds
 
 messagelogging:
   logstacktraces: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,9 +40,6 @@ queueconfig:
   outbound-exchange: action-outbound-exchange
   action-case-exchange: action-case-exchange
   uac-qid-created-exchange: uac-qid-created-exchange
-  consumers: 50
-  retry-attempts: 1
-  retry-delay: 1000 #milliseconds
 
 healthcheck:
   frequency: 1000 #milliseconds

--- a/src/test/java/uk/gov/ons/census/action/cache/UacQidCacheIT.java
+++ b/src/test/java/uk/gov/ons/census/action/cache/UacQidCacheIT.java
@@ -53,7 +53,7 @@ public class UacQidCacheIT {
   @Value("${uacservice.uacqid-fetch-count}")
   private int cacheFetch;
 
-  @Rule public WireMockRule mockUacQidService = new WireMockRule(wireMockConfig().port(8089));
+  @Rule public WireMockRule mockUacQidService = new WireMockRule(wireMockConfig().port(8899));
 
   /**
    * This test checks the nightmare scenario of something causing an endless loop of death

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -82,7 +82,6 @@ public class ChunkPollerIT {
     caseRepository.deleteAllInBatch();
     actionRuleRepository.deleteAllInBatch();
     actionPlanRepository.deleteAllInBatch();
-    mockUacQidService.resetAll(); // Hack for Travis unreliability problems
   }
 
   @Test
@@ -295,6 +294,7 @@ public class ChunkPollerIT {
         QueueSpy uacQidCreatedQueue = rabbitQueueHelper.listen(CASE_UAC_QID_CREATED_QUEUE)) {
       // Given
       UacQidDTO uacQidDto = stubCreateUacQid(1);
+      Thread.sleep(10000); // Workaround for dreadfulness of Travis
 
       ActionPlan actionPlan = setUpActionPlan();
       Case randomCase = setUpCase(actionPlan, 5);

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -82,6 +82,7 @@ public class ChunkPollerIT {
     caseRepository.deleteAllInBatch();
     actionRuleRepository.deleteAllInBatch();
     actionPlanRepository.deleteAllInBatch();
+    mockUacQidService.resetAll(); // Hack for Travis unreliability problems
   }
 
   @Test
@@ -294,7 +295,6 @@ public class ChunkPollerIT {
         QueueSpy uacQidCreatedQueue = rabbitQueueHelper.listen(CASE_UAC_QID_CREATED_QUEUE)) {
       // Given
       UacQidDTO uacQidDto = stubCreateUacQid(1);
-      Thread.sleep(5000); // Wait for Wiremock to sort itself out - Travis unreliable
 
       ActionPlan actionPlan = setUpActionPlan();
       Case randomCase = setUpCase(actionPlan, 5);

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -294,6 +294,7 @@ public class ChunkPollerIT {
         QueueSpy uacQidCreatedQueue = rabbitQueueHelper.listen(CASE_UAC_QID_CREATED_QUEUE)) {
       // Given
       UacQidDTO uacQidDto = stubCreateUacQid(1);
+      Thread.sleep(5000); // Wait for Wiremock to sort itself out - Travis unreliable
 
       ActionPlan actionPlan = setUpActionPlan();
       Case randomCase = setUpCase(actionPlan, 5);

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -84,6 +84,7 @@ public class ChunkPollerIT {
     caseRepository.deleteAllInBatch();
     actionRuleRepository.deleteAllInBatch();
     actionPlanRepository.deleteAllInBatch();
+    mockUacQidService.resetAll();
   }
 
   @Test
@@ -296,6 +297,8 @@ public class ChunkPollerIT {
         QueueSpy uacQidCreatedQueue = rabbitQueueHelper.listen(CASE_UAC_QID_CREATED_QUEUE)) {
       // Given
       UacQidDTO uacQidDto = stubCreateUacQid(1);
+      Thread.sleep(30000); // wait for wiremockery
+
       ActionPlan actionPlan = setUpActionPlan();
       Case randomCase = setUpCase(actionPlan, 5);
       ActionRule actionRule = setUpActionRule(ActionType.CE_IC03, actionPlan);

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -52,7 +52,6 @@ import uk.gov.ons.census.action.model.repository.FulfilmentToProcessRepository;
 @ContextConfiguration
 @SpringBootTest
 @ActiveProfiles("test")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ChunkPollerIT {
   private static final String MULTIPLE_QIDS_URL = "/multiple_qids";
@@ -84,7 +83,6 @@ public class ChunkPollerIT {
     caseRepository.deleteAllInBatch();
     actionRuleRepository.deleteAllInBatch();
     actionPlanRepository.deleteAllInBatch();
-    mockUacQidService.resetAll();
   }
 
   @Test
@@ -297,7 +295,6 @@ public class ChunkPollerIT {
         QueueSpy uacQidCreatedQueue = rabbitQueueHelper.listen(CASE_UAC_QID_CREATED_QUEUE)) {
       // Given
       UacQidDTO uacQidDto = stubCreateUacQid(1);
-      Thread.sleep(30000); // wait for wiremockery
 
       ActionPlan actionPlan = setUpActionPlan();
       Case randomCase = setUpCase(actionPlan, 5);
@@ -307,8 +304,8 @@ public class ChunkPollerIT {
       List<String> actualPrintMessages = new LinkedList<>();
       List<String> actualUacCreatedMessages = new LinkedList<>();
       for (int i = 0; i < 5; i++) {
-        String actualPrintMessage = printerQueue.getQueue().poll(20, TimeUnit.SECONDS);
-        String actualUacCreatedMessage = uacQidCreatedQueue.getQueue().poll(20, TimeUnit.SECONDS);
+        String actualPrintMessage = printerQueue.getQueue().poll(60, TimeUnit.SECONDS);
+        String actualUacCreatedMessage = uacQidCreatedQueue.getQueue().poll(60, TimeUnit.SECONDS);
         assertThat(actualPrintMessage).isNotNull();
         actualPrintMessages.add(actualPrintMessage);
         assertThat(actualUacCreatedMessage).isNotNull();

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -68,7 +68,7 @@ public class ChunkPollerIT {
   @Autowired private CaseToProcessRepository caseToProcessRepository;
   @Autowired private FulfilmentToProcessRepository fulfilmentToProcessRepository;
 
-  @Rule public WireMockRule mockUacQidService = new WireMockRule(wireMockConfig().port(8089));
+  @Rule public WireMockRule mockUacQidService = new WireMockRule(wireMockConfig().port(8899));
 
   @Before
   @Transactional

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -25,6 +25,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -51,6 +52,7 @@ import uk.gov.ons.census.action.model.repository.FulfilmentToProcessRepository;
 @ContextConfiguration
 @SpringBootTest
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ChunkPollerIT {
   private static final String MULTIPLE_QIDS_URL = "/multiple_qids";

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,4 +6,4 @@ spring:
 
 uacservice:
   connection:
-    port: 8089
+    port: 8899


### PR DESCRIPTION
# Motivation and Context
We saw a problem with Case Processor processing a Rabbit message more than once. This seemed to be due to the Spring retry code, but we can't be certain.

# What has changed
Reduced retry count to 1 for failed rabbit messages.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/SCSNxVxU