### PR TITLE
Use date type for dates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,10 @@
       <version>2.27.0</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
       <artifactId>hibernate-types-5</artifactId>
       <version>2.4.3</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
 
     <!--    Test Dependencies below this point -->
     <dependency>
@@ -92,10 +96,6 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>2.27.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
   </dependencies>
 

--- a/src/main/java/uk/gov/ons/census/action/builders/CaseSelectedBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/CaseSelectedBuilder.java
@@ -1,8 +1,6 @@
 package uk.gov.ons.census.action.builders;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import org.springframework.stereotype.Component;
 import uk.gov.ons.census.action.model.dto.Event;
@@ -51,7 +49,7 @@ public class CaseSelectedBuilder {
     event.setType(eventType);
     event.setSource("ACTION_WORKER");
     event.setChannel("RM");
-    event.setDateTime(DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.now(ZoneId.of("UTC"))));
+    event.setDateTime(OffsetDateTime.now());
     event.setTransactionId(UUID.randomUUID().toString());
 
     return responseManagementEvent;

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -4,8 +4,6 @@ import static uk.gov.ons.census.action.model.dto.EventType.RM_UAC_CREATED;
 import static uk.gov.ons.census.action.utility.ActionTypeHelper.isExpectedCapacityActionType;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -106,7 +104,7 @@ public class UacQidLinkBuilder {
 
     Event event = new Event();
     event.setType(RM_UAC_CREATED);
-    event.setDateTime(DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.now(ZoneId.of("UTC"))));
+    event.setDateTime(OffsetDateTime.now());
     event.setTransactionId(UUID.randomUUID().toString());
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
     responseManagementEvent.setEvent(event);

--- a/src/main/java/uk/gov/ons/census/action/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/action/config/AppConfig.java
@@ -2,6 +2,8 @@ package uk.gov.ons.census.action.config;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.TimeZone;
 import javax.annotation.PostConstruct;
 import org.springframework.amqp.core.AmqpAdmin;
@@ -35,6 +37,8 @@ public class AppConfig {
   @Bean
   public Jackson2JsonMessageConverter messageConverter() {
     ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return new Jackson2JsonMessageConverter(objectMapper);
   }

--- a/src/main/java/uk/gov/ons/census/action/model/dto/Event.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/Event.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.time.OffsetDateTime;
 import lombok.Data;
 
 @Data
@@ -7,6 +8,6 @@ public class Event {
   private EventType type;
   private String source;
   private String channel;
-  private String dateTime;
+  private OffsetDateTime dateTime;
   private String transactionId;
 }

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -13,6 +13,8 @@ import static uk.gov.ons.census.action.model.entity.ActionType.P_RL_1RL1_1;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -62,6 +64,11 @@ public class ChunkPollerIT {
   private static final String CASE_UAC_QID_CREATED_QUEUE = "case.uac-qid-created";
   private static final EasyRandom easyRandom = new EasyRandom();
   private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+  }
 
   @Autowired private RabbitQueueHelper rabbitQueueHelper;
   @Autowired private CaseRepository caseRepository;


### PR DESCRIPTION
# Motivation and Context
We want to take advantage of Java's strong typing, and to use `OffsetDateTime` for date types, not strings.

# What has changed
Changed anywhere that was using a string for date/time/timestamp to use `OffsetDateTime`.

# How to test?
Run the ATs - should be zero regression.

# Links
Trello: https://trello.com/c/PbcNYiWe