### PR TITLE
Fix IC02 treatment code bug

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -139,7 +139,7 @@ public class UacQidLinkBuilder {
         return getUacQidTupleWithSecondWelshPair(uacQidLinks, actionType);
       }
 
-    } else if (isStateCorrectForSingleUacQidPair(linkedCase, uacQidLinks)) {
+    } else if (isStateCorrectForSingleUacQidPair(linkedCase, uacQidLinks, actionType)) {
       return getUacQidTupleWithSinglePair(uacQidLinks);
     }
 
@@ -147,8 +147,11 @@ public class UacQidLinkBuilder {
         String.format("Wrong number of UACs for treatment code '%s'", actionType));
   }
 
-  private boolean isStateCorrectForSingleUacQidPair(Case linkedCase, List<UacQidLink> uacQidLinks) {
-    return !isQuestionnaireWelsh(linkedCase.getTreatmentCode())
+  private boolean isStateCorrectForSingleUacQidPair(
+      Case linkedCase, List<UacQidLink> uacQidLinks, ActionType actionType) {
+    return (!isQuestionnaireWelsh(linkedCase.getTreatmentCode())
+            // CE_IC02 is single QID letter but includes welsh questionnaire treatment codes
+            || actionType == ActionType.CE1_IC02)
         && uacQidLinks.size() == NUM_OF_UAC_QID_PAIRS_NEEDED_FOR_SINGLE_LANGUAGE;
   }
 

--- a/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
@@ -383,15 +383,18 @@ public class UacQidLinkBuilderTest {
     // We need to include welsh questionnaire treatment codes in the CE1 CE_IC02 letter run
     testCase.setTreatmentCode("CE_QDIEW");
 
-    // when
+    // When
     UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.CE1_IC02);
 
+    // Then
+    // The single CE1 QID pair is returned
     UacQidLink actualUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualUacQidLink.getQid()).isEqualTo(qidCE1Welsh);
     assertThat(actualUacQidLink.getUac()).isEqualTo(uacCE1Welsh);
     assertThat(actualUacQidLink.isActive()).isTrue();
 
+    // There should not be a second dual language QID pair
     assertThat(uacQidTuple.getUacQidLinkWales()).isNotPresent();
   }
 

--- a/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
@@ -81,13 +81,13 @@ public class UacQidLinkBuilderTest {
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
-    assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
+    assertThat(actualEnglandUacQidLink.isActive()).isFalse();
 
     UacQidLink actualWalesdUacQidLink = uacQidTuple.getUacQidLinkWales().get();
     assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualWalesdUacQidLink.getQid()).isEqualTo(qidWal);
     assertThat(actualWalesdUacQidLink.getUac()).isEqualTo(uacWal);
-    assertThat(actualWalesdUacQidLink.isActive()).isEqualTo(false);
+    assertThat(actualWalesdUacQidLink.isActive()).isFalse();
   }
 
   @Test
@@ -140,13 +140,13 @@ public class UacQidLinkBuilderTest {
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
-    assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
+    assertThat(actualEnglandUacQidLink.isActive()).isFalse();
 
     UacQidLink actualWalesdUacQidLink = uacQidTuple.getUacQidLinkWales().get();
     assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualWalesdUacQidLink.getQid()).isEqualTo(qidWal);
     assertThat(actualWalesdUacQidLink.getUac()).isEqualTo(uacWal);
-    assertThat(actualWalesdUacQidLink.isActive()).isEqualTo(false);
+    assertThat(actualWalesdUacQidLink.isActive()).isFalse();
   }
 
   @Test
@@ -199,13 +199,13 @@ public class UacQidLinkBuilderTest {
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
-    assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
+    assertThat(actualEnglandUacQidLink.isActive()).isFalse();
 
     UacQidLink actualWalesdUacQidLink = uacQidTuple.getUacQidLinkWales().get();
     assertThat(actualWalesdUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualWalesdUacQidLink.getQid()).isEqualTo(qidWal);
     assertThat(actualWalesdUacQidLink.getUac()).isEqualTo(uacWal);
-    assertThat(actualWalesdUacQidLink.isActive()).isEqualTo(false);
+    assertThat(actualWalesdUacQidLink.isActive()).isFalse();
   }
 
   @Test
@@ -233,9 +233,9 @@ public class UacQidLinkBuilderTest {
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
     assertThat(actualEnglandUacQidLink.getQid()).isEqualTo(qidEng);
     assertThat(actualEnglandUacQidLink.getUac()).isEqualTo(uacEng);
-    assertThat(actualEnglandUacQidLink.isActive()).isEqualTo(false);
+    assertThat(actualEnglandUacQidLink.isActive()).isFalse();
 
-    assertThat(uacQidTuple.getUacQidLinkWales().isPresent()).isEqualTo(false);
+    assertThat(uacQidTuple.getUacQidLinkWales()).isNotPresent();
   }
 
   @Test(expected = RuntimeException.class)
@@ -361,6 +361,38 @@ public class UacQidLinkBuilderTest {
 
     // Then
     // Exception thrown - expected
+  }
+
+  @Test
+  public void testIC02WorksForWelshQuestionnaireCECase() {
+    // Given
+    Case testCase = easyRandom.nextObject(Case.class);
+    String uacCE1Welsh = easyRandom.nextObject(String.class);
+    String qidCE1Welsh = "3220000010732199";
+
+    List<UacQidLink> uacQidLinks = new ArrayList<>();
+    UacQidLink uacQidLink = new UacQidLink();
+    uacQidLink.setCaseId(testCase.getCaseId());
+    uacQidLink.setUac(uacCE1Welsh);
+    uacQidLink.setQid(qidCE1Welsh);
+    uacQidLink.setActive(true);
+    uacQidLinks.add(uacQidLink);
+
+    when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
+    
+    // We need to include welsh questionnaire treatment codes in the CE1 CE_IC02 letter run
+    testCase.setTreatmentCode("CE_QDIEW");
+
+    // when
+    UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.CE1_IC02);
+
+    UacQidLink actualUacQidLink = uacQidTuple.getUacQidLink();
+    assertThat(actualUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
+    assertThat(actualUacQidLink.getQid()).isEqualTo(qidCE1Welsh);
+    assertThat(actualUacQidLink.getUac()).isEqualTo(uacCE1Welsh);
+    assertThat(actualUacQidLink.isActive()).isTrue();
+
+    assertThat(uacQidTuple.getUacQidLinkWales()).isNotPresent();
   }
 
   @Test(expected = RuntimeException.class)

--- a/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
@@ -379,7 +379,7 @@ public class UacQidLinkBuilderTest {
     uacQidLinks.add(uacQidLink);
 
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
-    
+
     // We need to include welsh questionnaire treatment codes in the CE1 CE_IC02 letter run
     testCase.setTreatmentCode("CE_QDIEW");
 


### PR DESCRIPTION
# Motivation and Context:
The action worker was failing to process IC02 action rules because the classifiers now include a welsh questionnaire treatment code. It does not expect these cases to be in action rules with just a single QID but this is the CE1 form initial contact run which is different.

# What has changed?
* Ignore the welsh questionnaire treatment code check for IC02 action types

# How to test?
Run the fix AT's branch, it includes the offending treatment code.

# Links:
https://trello.com/c/pecodLkt/1115-bug-cant-run-ce1-print-file-for-estabs-with-no-addressed-units