### PR TITLE
Allow batch ID to be sent on RM_UAC_CREATED

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -36,7 +36,8 @@ public class PrintFileDtoBuilder {
     // "EQ launched but not submitted/completed" reminders don't have a UAC-QID pair for security
     // because the respondent has already partially filled in their EQ.
     if (!doesNotRequireUacQidActionTypes.contains(actionType)) {
-      UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType);
+      UacQidTuple uacQidTuple =
+          uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType, batchUUID);
 
       printFileDto.setUac(uacQidTuple.getUacQidLink().getUac());
       printFileDto.setQid(uacQidTuple.getUacQidLink().getQid());
@@ -53,7 +54,7 @@ public class PrintFileDtoBuilder {
     printFileDto.setAddressLine3(selectedCase.getAddressLine3());
     printFileDto.setTownName(selectedCase.getTownName());
     printFileDto.setPostcode(selectedCase.getPostcode());
-    printFileDto.setBatchId(batchUUID.toString());
+    printFileDto.setBatchId(batchUUID);
     printFileDto.setPackCode(packCode);
     printFileDto.setActionType(actionType.toString());
     printFileDto.setFieldCoordinatorId(selectedCase.getFieldCoordinatorId());

--- a/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilder.java
@@ -29,7 +29,7 @@ public class PrintFileDtoBuilder {
   }
 
   public PrintFileDto buildPrintFileDto(
-      Case selectedCase, String packCode, UUID batchUUID, ActionType actionType) {
+      Case selectedCase, String packCode, UUID batchId, ActionType actionType, UUID actionRuleId) {
 
     PrintFileDto printFileDto = new PrintFileDto();
 
@@ -37,7 +37,7 @@ public class PrintFileDtoBuilder {
     // because the respondent has already partially filled in their EQ.
     if (!doesNotRequireUacQidActionTypes.contains(actionType)) {
       UacQidTuple uacQidTuple =
-          uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType, batchUUID);
+          uacQidLinkBuilder.getUacQidLinks(selectedCase, actionType, actionRuleId);
 
       printFileDto.setUac(uacQidTuple.getUacQidLink().getUac());
       printFileDto.setQid(uacQidTuple.getUacQidLink().getQid());
@@ -54,7 +54,7 @@ public class PrintFileDtoBuilder {
     printFileDto.setAddressLine3(selectedCase.getAddressLine3());
     printFileDto.setTownName(selectedCase.getTownName());
     printFileDto.setPostcode(selectedCase.getPostcode());
-    printFileDto.setBatchId(batchUUID);
+    printFileDto.setBatchId(batchId);
     printFileDto.setPackCode(packCode);
     printFileDto.setActionType(actionType.toString());
     printFileDto.setFieldCoordinatorId(selectedCase.getFieldCoordinatorId());

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -98,11 +98,11 @@ public class UacQidLinkBuilder {
   }
 
   public UacQidLink createNewUacQidPair(
-      Case linkedCase, String questionnaireType, UUID actionRuleOrFulfilmentBatchId) {
+      Case linkedCase, String questionnaireType, UUID batchId) {
     UacQidDTO newUacQidPair = uacQidCache.getUacQidPair(Integer.parseInt(questionnaireType));
     UacQidCreated uacQidCreated = new UacQidCreated();
     uacQidCreated.setCaseId(linkedCase.getCaseId());
-    uacQidCreated.setBatchId(actionRuleOrFulfilmentBatchId);
+    uacQidCreated.setBatchId(batchId);
     uacQidCreated.setQid(newUacQidPair.getQid());
     uacQidCreated.setUac(newUacQidPair.getUac());
 

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -97,8 +97,7 @@ public class UacQidLinkBuilder {
     }
   }
 
-  public UacQidLink createNewUacQidPair(
-      Case linkedCase, String questionnaireType, UUID batchId) {
+  public UacQidLink createNewUacQidPair(Case linkedCase, String questionnaireType, UUID batchId) {
     UacQidDTO newUacQidPair = uacQidCache.getUacQidPair(Integer.parseInt(questionnaireType));
     UacQidCreated uacQidCreated = new UacQidCreated();
     uacQidCreated.setCaseId(linkedCase.getCaseId());

--- a/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
+++ b/src/main/java/uk/gov/ons/census/action/builders/UacQidLinkBuilder.java
@@ -83,23 +83,26 @@ public class UacQidLinkBuilder {
     this.uacQidCreatedExchange = uacQidCreatedExchange;
   }
 
-  public UacQidTuple getUacQidLinks(Case linkedCase, ActionType actionType, UUID batchId) {
+  public UacQidTuple getUacQidLinks(
+      Case linkedCase, ActionType actionType, UUID actionRuleOrFulfilmentBatchId) {
     if (isInitialContactNotExpectedCapacityActionType(actionType)) {
       return fetchExistingUacQidPairsForAction(linkedCase, actionType);
     } else if (isExpectedCapacityActionType(actionType)) {
       // We override the address level for these action types because we want to create individual
       // uac qid pairs
-      return createNewUacQidPairsForAction(linkedCase, actionType, "U", batchId);
+      return createNewUacQidPairsForAction(
+          linkedCase, actionType, "U", actionRuleOrFulfilmentBatchId);
     } else {
-      return createNewUacQidPairsForAction(linkedCase, actionType, batchId);
+      return createNewUacQidPairsForAction(linkedCase, actionType, actionRuleOrFulfilmentBatchId);
     }
   }
 
-  public UacQidLink createNewUacQidPair(Case linkedCase, String questionnaireType, UUID batchId) {
+  public UacQidLink createNewUacQidPair(
+      Case linkedCase, String questionnaireType, UUID actionRuleOrFulfilmentBatchId) {
     UacQidDTO newUacQidPair = uacQidCache.getUacQidPair(Integer.parseInt(questionnaireType));
     UacQidCreated uacQidCreated = new UacQidCreated();
     uacQidCreated.setCaseId(linkedCase.getCaseId());
-    uacQidCreated.setBatchId(batchId);
+    uacQidCreated.setBatchId(actionRuleOrFulfilmentBatchId);
     uacQidCreated.setQid(newUacQidPair.getQid());
     uacQidCreated.setUac(newUacQidPair.getUac());
 
@@ -189,28 +192,36 @@ public class UacQidLinkBuilder {
   }
 
   private UacQidTuple createNewUacQidPairsForAction(
-      Case linkedCase, ActionType actionType, String addressLevel, UUID batchId) {
+      Case linkedCase,
+      ActionType actionType,
+      String addressLevel,
+      UUID actionRuleOrFulfilmentBatchId) {
     UacQidTuple uacQidTuple = new UacQidTuple();
     String questionnaireType =
         calculateQuestionnaireType(linkedCase.getCaseType(), linkedCase.getRegion(), addressLevel);
 
-    uacQidTuple.setUacQidLink(createNewUacQidPair(linkedCase, questionnaireType, batchId));
+    uacQidTuple.setUacQidLink(
+        createNewUacQidPair(linkedCase, questionnaireType, actionRuleOrFulfilmentBatchId));
     if (actionType.equals(ActionType.P_QU_H2)) {
       uacQidTuple.setUacQidLinkWales(
-          Optional.of(createNewUacQidPair(linkedCase, WALES_IN_WELSH_QUESTIONNAIRE_TYPE, batchId)));
+          Optional.of(
+              createNewUacQidPair(
+                  linkedCase, WALES_IN_WELSH_QUESTIONNAIRE_TYPE, actionRuleOrFulfilmentBatchId)));
     } else if (actionType.equals(ActionType.CE_IC10)) {
       uacQidTuple.setUacQidLinkWales(
           Optional.of(
               createNewUacQidPair(
-                  linkedCase, WALES_IN_WELSH_QUESTIONNAIRE_TYPE_CE_CASES, batchId)));
+                  linkedCase,
+                  WALES_IN_WELSH_QUESTIONNAIRE_TYPE_CE_CASES,
+                  actionRuleOrFulfilmentBatchId)));
     }
     return uacQidTuple;
   }
 
   private UacQidTuple createNewUacQidPairsForAction(
-      Case linkedCase, ActionType actionType, UUID batchId) {
+      Case linkedCase, ActionType actionType, UUID actionRuleOrFulfilmentBatchId) {
     return createNewUacQidPairsForAction(
-        linkedCase, actionType, linkedCase.getAddressLevel(), batchId);
+        linkedCase, actionType, linkedCase.getAddressLevel(), actionRuleOrFulfilmentBatchId);
   }
 
   private boolean isQuestionnaireWelsh(String treatmentCode) {

--- a/src/main/java/uk/gov/ons/census/action/model/dto/PrintFileDto.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/PrintFileDto.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.action.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -17,7 +18,7 @@ public class PrintFileDto {
   private String addressLine3;
   private String townName;
   private String postcode;
-  private String batchId;
+  private UUID batchId;
   private int batchQuantity;
   private String packCode;
   private String actionType;

--- a/src/main/java/uk/gov/ons/census/action/model/dto/UacQidCreated.java
+++ b/src/main/java/uk/gov/ons/census/action/model/dto/UacQidCreated.java
@@ -8,4 +8,5 @@ public class UacQidCreated {
   private String uac;
   private String qid;
   private UUID caseId;
+  private UUID batchId;
 }

--- a/src/main/java/uk/gov/ons/census/action/poller/CaseProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/poller/CaseProcessor.java
@@ -68,7 +68,8 @@ public class CaseProcessor {
               caseToProcess.getCaze(),
               triggeredActionRule.getActionType().getPackCode(),
               batchId,
-              triggeredActionRule.getActionType());
+              triggeredActionRule.getActionType(),
+              triggeredActionRule.getId());
       printFileDto.setBatchQuantity(batchQty);
       rabbitTemplate.convertAndSend(outboundExchange, routingKey, printFileDto);
     }

--- a/src/main/java/uk/gov/ons/census/action/poller/FulfilmentProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/poller/FulfilmentProcessor.java
@@ -80,7 +80,7 @@ public class FulfilmentProcessor {
   private PrintFileDto buildPrintFileDto(FulfilmentToProcess fulfilmentToProcess) {
     PrintFileDto fulfilmentPrintFile = new PrintFileDto();
 
-    fulfilmentPrintFile.setBatchId(fulfilmentToProcess.getBatchId().toString());
+    fulfilmentPrintFile.setBatchId(fulfilmentToProcess.getBatchId());
     fulfilmentPrintFile.setBatchQuantity(fulfilmentToProcess.getQuantity());
 
     fulfilmentPrintFile.setActionType(fulfilmentToProcess.getActionType().name());
@@ -107,7 +107,9 @@ public class FulfilmentProcessor {
     if (questionnaireType.isPresent()) {
       UacQidLink uacQid =
           uacQidLinkBuilder.createNewUacQidPair(
-              fulfilmentToProcess.getCaze(), questionnaireType.get().toString());
+              fulfilmentToProcess.getCaze(),
+              questionnaireType.get().toString(),
+              fulfilmentToProcess.getBatchId());
       fulfilmentPrintFile.setQid(uacQid.getQid());
       fulfilmentPrintFile.setUac(uacQid.getUac());
     }

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -52,7 +52,8 @@ public class PrintFileDtoBuilderTest {
             testCaze,
             actionTypeToPackCodeMap.get(expectedActionType),
             BATCH_UUID,
-            ActionType.ICHHQW);
+            ActionType.ICHHQW,
+            UUID.randomUUID());
 
     // Then
     assertThat(actualPrintFileDto).isEqualToComparingFieldByField(expectedPrintFileDto);
@@ -75,7 +76,8 @@ public class PrintFileDtoBuilderTest {
             testCaze,
             actionTypeToPackCodeMap.get(expectedActionType),
             BATCH_UUID,
-            ActionType.P_RL_1RL1A);
+            ActionType.P_RL_1RL1A,
+            UUID.randomUUID());
 
     // Then
     assertThat(actualPrintFileDto).isEqualToComparingFieldByField(expectedPrintFileDto);

--- a/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/PrintFileDtoBuilderTest.java
@@ -94,7 +94,7 @@ public class PrintFileDtoBuilderTest {
     uacQidTuple.setUacQidLinkWales(Optional.of(welshLink));
 
     UacQidLinkBuilder uacQidLinkBuilder = mock(UacQidLinkBuilder.class);
-    when(uacQidLinkBuilder.getUacQidLinks(any(Case.class), any(ActionType.class)))
+    when(uacQidLinkBuilder.getUacQidLinks(any(Case.class), any(ActionType.class), any(UUID.class)))
         .thenReturn(uacQidTuple);
 
     return uacQidLinkBuilder;
@@ -117,8 +117,7 @@ public class PrintFileDtoBuilderTest {
     printFileDto.setAddressLine3(caze.getAddressLine3());
     printFileDto.setTownName(caze.getTownName());
     printFileDto.setPostcode(caze.getPostcode());
-
-    printFileDto.setBatchId(BATCH_UUID.toString());
+    printFileDto.setBatchId(BATCH_UUID);
     printFileDto.setPackCode(actionTypeToPackCodeMap.get(expectedActionType));
     printFileDto.setActionType(actionType.toString());
     printFileDto.setFieldCoordinatorId(caze.getFieldCoordinatorId());

--- a/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
+++ b/src/test/java/uk/gov/ons/census/action/builders/UacQidLinkBuilderTest.java
@@ -75,7 +75,8 @@ public class UacQidLinkBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // when
-    UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
+    UacQidTuple uacQidTuple =
+        uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW, UUID.randomUUID());
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
@@ -134,7 +135,8 @@ public class UacQidLinkBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // when
-    UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.SPG_IC14);
+    UacQidTuple uacQidTuple =
+        uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.SPG_IC14, UUID.randomUUID());
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
@@ -193,7 +195,8 @@ public class UacQidLinkBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // when
-    UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.CE_IC10);
+    UacQidTuple uacQidTuple =
+        uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.CE_IC10, UUID.randomUUID());
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
@@ -227,7 +230,8 @@ public class UacQidLinkBuilderTest {
     testCase.setTreatmentCode("NotWelshTreatmentCode");
 
     // when
-    UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICL1E);
+    UacQidTuple uacQidTuple =
+        uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICL1E, UUID.randomUUID());
 
     UacQidLink actualEnglandUacQidLink = uacQidTuple.getUacQidLink();
     assertThat(actualEnglandUacQidLink.getCaseId()).isEqualTo(testCase.getCaseId());
@@ -261,7 +265,7 @@ public class UacQidLinkBuilderTest {
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     // When
-    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
+    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW, UUID.randomUUID());
 
     // Then
     // Exception thrown - expected
@@ -290,7 +294,7 @@ public class UacQidLinkBuilderTest {
     when(uacQidLinkRepository.findByCaseId(testCase.getCaseId())).thenReturn(uacQidLinks);
 
     // When
-    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
+    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW, UUID.randomUUID());
 
     // Then
     // Exception thrown - The second welsh QID must have questionnaire type "03"
@@ -329,7 +333,7 @@ public class UacQidLinkBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // When
-    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
+    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW, UUID.randomUUID());
 
     // Then
     // Exception thrown - expected
@@ -357,7 +361,7 @@ public class UacQidLinkBuilderTest {
             + WALES_TREATMENT_CODE_SUFFIX);
 
     // When
-    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
+    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW, UUID.randomUUID());
 
     // Then
     // Exception thrown - expected
@@ -384,7 +388,8 @@ public class UacQidLinkBuilderTest {
     testCase.setTreatmentCode("CE_QDIEW");
 
     // When
-    UacQidTuple uacQidTuple = uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.CE1_IC02);
+    UacQidTuple uacQidTuple =
+        uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.CE1_IC02, UUID.randomUUID());
 
     // Then
     // The single CE1 QID pair is returned
@@ -412,7 +417,7 @@ public class UacQidLinkBuilderTest {
         .thenReturn(Collections.EMPTY_LIST);
 
     // When
-    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICL1E);
+    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICL1E, UUID.randomUUID());
 
     // Then
     // Exception thrown - expected
@@ -447,7 +452,7 @@ public class UacQidLinkBuilderTest {
     when(uacQidLinkRepository.findByCaseId(eq(testCase.getCaseId()))).thenReturn(uacQidLinks);
 
     // When
-    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW);
+    uacQidLinkBuilder.getUacQidLinks(testCase, ActionType.ICHHQW, UUID.randomUUID());
 
     // Then
     // Exception thrown - expected
@@ -466,7 +471,7 @@ public class UacQidLinkBuilderTest {
 
     // When
     UacQidTuple actualUacQidTuple =
-        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.P_RL_1RL1_1);
+        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.P_RL_1RL1_1, UUID.randomUUID());
 
     // Then
     verify(uacQidCache).getUacQidPair(eq(Integer.parseInt(ENGLISH_QUESTIONNAIRE_TYPE)));
@@ -499,7 +504,7 @@ public class UacQidLinkBuilderTest {
 
     // When
     UacQidTuple actualUacQidTuple =
-        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.P_QU_H1);
+        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.P_QU_H1, UUID.randomUUID());
 
     // Then
     verify(uacQidCache).getUacQidPair(eq(Integer.parseInt(ENGLISH_QUESTIONNAIRE_TYPE)));
@@ -536,7 +541,7 @@ public class UacQidLinkBuilderTest {
 
     // When
     UacQidTuple actualUacQidTuple =
-        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.P_QU_H2);
+        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.P_QU_H2, UUID.randomUUID());
 
     // Then
     verify(uacQidCache).getUacQidPair(eq(Integer.parseInt(WALES_IN_ENGLISH_QUESTIONNAIRE_TYPE)));
@@ -573,7 +578,7 @@ public class UacQidLinkBuilderTest {
 
     // When
     UacQidTuple actualUacQidTuple =
-        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.CE_IC10);
+        uacQidLinkBuilder.getUacQidLinks(linkedCase, ActionType.CE_IC10, UUID.randomUUID());
 
     // Then
     verify(uacQidCache)

--- a/src/test/java/uk/gov/ons/census/action/poller/CaseProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/CaseProcessorTest.java
@@ -62,7 +62,7 @@ public class CaseProcessorTest {
     printFileDto.setPackCode("P_IC_ICL1");
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
 
-    when(printFileDtoBuilder.buildPrintFileDto(any(), any(), any(), any()))
+    when(printFileDtoBuilder.buildPrintFileDto(any(), any(), any(), any(), any()))
         .thenReturn(printFileDto);
     when(caseSelectedBuilder.buildPrintMessage(
             any(UUID.class), anyLong(), anyString(), any(UUID.class)))
@@ -74,7 +74,11 @@ public class CaseProcessorTest {
     // Then
     verify(printFileDtoBuilder)
         .buildPrintFileDto(
-            eq(caze), eq("P_IC_ICL1"), eq(caseToProcess.getBatchId()), eq(ActionType.ICL1E));
+            eq(caze),
+            eq("P_IC_ICL1"),
+            eq(caseToProcess.getBatchId()),
+            eq(ActionType.ICL1E),
+            eq(actionRule.getId()));
     verify(caseSelectedBuilder)
         .buildPrintMessage(
             eq(caseToProcess.getBatchId()),
@@ -108,7 +112,7 @@ public class CaseProcessorTest {
     printFileDto.setPackCode("D_ICA_ICLR1");
     ResponseManagementEvent responseManagementEvent = new ResponseManagementEvent();
 
-    when(printFileDtoBuilder.buildPrintFileDto(any(), any(), any(), any()))
+    when(printFileDtoBuilder.buildPrintFileDto(any(), any(), any(), any(), any()))
         .thenReturn(printFileDto);
     when(caseSelectedBuilder.buildPrintMessage(
             any(UUID.class), anyLong(), anyString(), any(UUID.class)))
@@ -120,7 +124,11 @@ public class CaseProcessorTest {
     // Then
     verify(printFileDtoBuilder, times(5))
         .buildPrintFileDto(
-            eq(caze), eq("D_ICA_ICLR1"), eq(caseToProcess.getBatchId()), eq(ActionType.CE_IC03));
+            eq(caze),
+            eq("D_ICA_ICLR1"),
+            eq(caseToProcess.getBatchId()),
+            eq(ActionType.CE_IC03),
+            eq(actionRule.getId()));
     verify(caseSelectedBuilder)
         .buildPrintMessage(
             eq(caseToProcess.getBatchId()),

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkPollerIT.java
@@ -161,7 +161,7 @@ public class ChunkPollerIT {
               "batchQuantity",
               "packCode",
               "actionType");
-      assertThat(actualPrintFileDto.getBatchId()).isEqualTo(caseToProcess.getBatchId().toString());
+      assertThat(actualPrintFileDto.getBatchId()).isEqualTo(caseToProcess.getBatchId());
       assertThat(actualPrintFileDto.getBatchQuantity()).isEqualTo(caseToProcess.getBatchQuantity());
     }
   }
@@ -250,7 +250,7 @@ public class ChunkPollerIT {
               "batchQuantity",
               "packCode",
               "actionType");
-      assertThat(actualPrintFileDto.getBatchId()).isEqualTo(caseToProcess.getBatchId().toString());
+      assertThat(actualPrintFileDto.getBatchId()).isEqualTo(caseToProcess.getBatchId());
       assertThat(actualPrintFileDto.getBatchQuantity()).isEqualTo(caseToProcess.getBatchQuantity());
     }
   }
@@ -454,8 +454,7 @@ public class ChunkPollerIT {
               "batchQuantity",
               "packCode",
               "actionType");
-      assertThat(actualPrintFileDto.getBatchId())
-          .isEqualTo(fulfilmentToProcess.getBatchId().toString());
+      assertThat(actualPrintFileDto.getBatchId()).isEqualTo(fulfilmentToProcess.getBatchId());
       assertThat(actualPrintFileDto.getBatchQuantity())
           .isEqualTo(fulfilmentToProcess.getQuantity());
     }

--- a/src/test/java/uk/gov/ons/census/action/poller/FulfilmentProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/FulfilmentProcessorTest.java
@@ -49,7 +49,7 @@ public class FulfilmentProcessorTest {
     fulfilmentToProcess.setBatchId(UUID.randomUUID());
 
     UacQidLink uacQidLink = easyRandom.nextObject(UacQidLink.class);
-    when(uacQidLinkBuilder.createNewUacQidPair(any(Case.class), anyString()))
+    when(uacQidLinkBuilder.createNewUacQidPair(any(Case.class), anyString(), any(UUID.class)))
         .thenReturn(uacQidLink);
 
     ResponseManagementEvent printMessage = easyRandom.nextObject(ResponseManagementEvent.class);
@@ -91,7 +91,9 @@ public class FulfilmentProcessorTest {
     assertThat(printFileDto.getUac()).isEqualTo(uacQidLink.getUac());
     assertThat(printFileDto.getQid()).isEqualTo(uacQidLink.getQid());
 
-    verify(uacQidLinkBuilder).createNewUacQidPair(eq(fulfilmentToProcess.getCaze()), eq("1"));
+    verify(uacQidLinkBuilder)
+        .createNewUacQidPair(
+            eq(fulfilmentToProcess.getCaze()), eq("1"), eq(fulfilmentToProcess.getBatchId()));
 
     verify(caseSelectedBuilder)
         .buildPrintMessage(


### PR DESCRIPTION
# Motivation and Context
Although we don't store batch IDs anywhere - they're transient - we will be able to see all the UACs created by a particular Action (rule or fulfilment) batch, grouped together.

# What has changed
Allow batch ID to be sent, received and stored against any UACs created by RM.

# How to test?
Trigger a reminder rule. All the UACs that get created should have the same batch ID.

# Links
Trello: https://trello.com/c/ELepDger