### PR TITLE
Increase scheduled task thread pool to fix thread exhaustion issue

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
   task:
     scheduling:
       pool:
-        size: 2
+        size: 10
 
 queueconfig:
   outbound-exchange: action-outbound-exchange


### PR DESCRIPTION
# Motivation and Context:
Action Worker had some extra gubbins added to it to process fulfilments, but the size of the thread pool for scheduled tasks was never increased, so it can only do two simultaneous tasks, but it's trying to do three: process regular actions, process fulfilments, do the healthcheck.

# What has changed?
Increased the size of the thread pool for scheduled tasks to 10 to give a little headroom. 3 should be enough, but the implications of code changes are not always fully considered, so a little slack's not going to hurt.

# How to test?
Run an action rule at the same time as a bunch of fulfilments are being processed - k8s shouldn't bounce the pod, because the healthcheck will remain healthy instead of being thread starved.

# Links:
Trello: https://trello.com/c/bES9aLct