### PR TITLE
reduce the max db connection pool size to 10

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
     driverClassName: org.postgresql.Driver
     initialization-mode: always
     hikari:
-      maximumPoolSize: 50
+      maximumPoolSize: 10
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL94Dialect


### PR DESCRIPTION
# Motivation and Context:
action-worked only needs a minimal amount of db connections as its not multithreaded

# What has changed?
reduce the configured maximumPoolSize from 50 to 10

# How to test?
- just run AT's, shouldn't have any adverse affect
