### PR TITLE
Stop DB being hammered by fulfilment copypasta

### DIFF
--- a/src/main/java/uk/gov/ons/census/action/model/repository/FulfilmentToProcessRepository.java
+++ b/src/main/java/uk/gov/ons/census/action/model/repository/FulfilmentToProcessRepository.java
@@ -9,6 +9,8 @@ import uk.gov.ons.census.action.model.entity.FulfilmentToProcess;
 
 public interface FulfilmentToProcessRepository extends JpaRepository<FulfilmentToProcess, UUID> {
 
+  long countByBatchIdNotNull();
+
   @Query(
       value =
           "SELECT * FROM actionv2.fulfilment_to_process where batch_id is not null and quantity is not null LIMIT :limit FOR UPDATE SKIP LOCKED",

--- a/src/main/java/uk/gov/ons/census/action/poller/ChunkProcessor.java
+++ b/src/main/java/uk/gov/ons/census/action/poller/ChunkProcessor.java
@@ -62,6 +62,6 @@ public class ChunkProcessor {
 
   @Transactional
   public boolean isThereFulfilmentWorkToDo() {
-    return fulfilmentToProcessRepository.count() > 0;
+    return fulfilmentToProcessRepository.countByBatchIdNotNull() > 0;
   }
 }

--- a/src/test/java/uk/gov/ons/census/action/poller/ChunkProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/action/poller/ChunkProcessorTest.java
@@ -99,26 +99,26 @@ public class ChunkProcessorTest {
   @Test
   public void testIsThereFulfilmentWorkToDoNoThereIsNot() {
     // Given
-    when(fulfilmentToProcessRepository.count()).thenReturn(0L);
+    when(fulfilmentToProcessRepository.countByBatchIdNotNull()).thenReturn(0L);
 
     // When
     boolean actualResult = underTest.isThereFulfilmentWorkToDo();
 
     // Then
-    verify(fulfilmentToProcessRepository).count();
+    verify(fulfilmentToProcessRepository).countByBatchIdNotNull();
     assertThat(actualResult).isFalse();
   }
 
   @Test
   public void testIsThereFulfilmentWorkToDoYesThereIs() {
     // Given
-    when(fulfilmentToProcessRepository.count()).thenReturn(666L);
+    when(fulfilmentToProcessRepository.countByBatchIdNotNull()).thenReturn(666L);
 
     // When
     boolean actualResult = underTest.isThereFulfilmentWorkToDo();
 
     // Then
-    verify(fulfilmentToProcessRepository).count();
+    verify(fulfilmentToProcessRepository).countByBatchIdNotNull();
     assertThat(actualResult).isTrue();
   }
 }


### PR DESCRIPTION
# Motivation and Context:
The `case_to_process` table contains data which is _ready_ to be processed. The `fulfilment_to_process` table contains data which is _waiting_ for the fulfilment cron schedule to trigger. So, for almost 24 hours a day, the database is being continuously hammered by the copypasta.

# What has changed?
Replaced copypasta with correct query to check to see if there's any work to do.

# How to test?
Should work the same as before.

# Links:
Trello: https://trello.com/c/yZfUWhxe

# Screenshots (if appropriate):
<img width="1003" alt="Screenshot 2021-01-26 at 13 40 28" src="https://user-images.githubusercontent.com/41681172/105852961-0cace280-5fdd-11eb-971e-204d3afcaa7b.png">
